### PR TITLE
Lazy-load hero portraits in hero list windows

### DIFF
--- a/client/lobby/BattleOnlyModeTab.cpp
+++ b/client/lobby/BattleOnlyModeTab.cpp
@@ -497,25 +497,7 @@ void BattleOnlyModeHeroSelector::selectHero()
 	}
 
 	// Load portraits lazily: only visible list items are created, so avoid decoding all of them upfront.
-	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
-	auto imageLoader = [imageCache, heroIconIndices](size_t index) -> std::shared_ptr<IImage>
-	{
-		if(index >= heroIconIndices.size())
-			return nullptr;
-
-		int32_t iconIndex = heroIconIndices[index];
-		if(iconIndex < 0)
-			return nullptr;
-
-		auto it = imageCache->find(static_cast<int32_t>(index));
-		if(it != imageCache->end())
-			return it->second;
-
-		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), iconIndex, 0, EImageBlitMode::OPAQUE);
-		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
-		(*imageCache)[static_cast<int32_t>(index)] = image;
-		return image;
-	};
+	auto imageLoader = CObjectListWindow::makeLazyHeroPortraitLoader(std::move(heroIconIndices));
 	auto window = std::make_shared<CObjectListWindow>(texts, nullptr, LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), [this, heroes](int index){
 		if(index == 0)
 		{

--- a/client/lobby/BattleOnlyModeTab.cpp
+++ b/client/lobby/BattleOnlyModeTab.cpp
@@ -486,18 +486,36 @@ void BattleOnlyModeHeroSelector::selectHero()
 	})));
 	
 	std::vector<std::string> texts;
-	std::vector<std::shared_ptr<IImage>> images;
+	std::vector<int32_t> heroIconIndices;
 	// Add "no hero" option
 	texts.push_back(LIBRARY->generaltexth->translate("core.genrltxt.507"));
-	images.push_back(nullptr);
+	heroIconIndices.push_back(-1);
 	for (const auto & h : heroes)
 	{
 		texts.push_back(h.toHeroType()->getNameTranslated());
-
-		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), h.toHeroType()->imageIndex, 0, EImageBlitMode::OPAQUE);
-		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
-		images.push_back(image);
+		heroIconIndices.push_back(h.toHeroType()->imageIndex);
 	}
+
+	// Load portraits lazily: only visible list items are created, so avoid decoding all of them upfront.
+	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
+	auto imageLoader = [imageCache, heroIconIndices](size_t index) -> std::shared_ptr<IImage>
+	{
+		if(index >= heroIconIndices.size())
+			return nullptr;
+
+		int32_t iconIndex = heroIconIndices[index];
+		if(iconIndex < 0)
+			return nullptr;
+
+		auto it = imageCache->find(static_cast<int32_t>(index));
+		if(it != imageCache->end())
+			return it->second;
+
+		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), iconIndex, 0, EImageBlitMode::OPAQUE);
+		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
+		(*imageCache)[static_cast<int32_t>(index)] = image;
+		return image;
+	};
 	auto window = std::make_shared<CObjectListWindow>(texts, nullptr, LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), [this, heroes](int index){
 		if(index == 0)
 		{
@@ -521,7 +539,7 @@ void BattleOnlyModeHeroSelector::selectHero()
 		parent.startInfo->spellBook[id] = heroes[index].toHeroType()->haveSpellBook;
 
 		parent.onChange();
-	}, selectedIndex, images, true, true);
+	}, selectedIndex, imageLoader, true, true);
 	window->onPopup = [heroes](int index) {
 		if(index == 0)
 			return;

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -768,8 +768,8 @@ void CTavernWindow::chooseHeroToInvite(CGHeroInstance* selectedHero, const std::
 	orderedHeroes.insert(inviteableHeroes.begin(), inviteableHeroes.end());
 
 	std::vector<std::string> texts;
-	std::vector<std::shared_ptr<IImage>> images;
 	std::vector<CGHeroInstance*> heroes;
+	std::vector<int32_t> heroIconIndices;
 	for (const auto & h : orderedHeroes)
 	{
 		heroes.push_back(h.second);
@@ -778,10 +778,7 @@ void CTavernWindow::chooseHeroToInvite(CGHeroInstance* selectedHero, const std::
 		auto hero = heroFromMapPool ? heroFromMapPool : h.second;
 
 		texts.push_back(GAME->translator().translate(hero->getNameTextID()));
-
-		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), hero->getIconIndex(), 0, EImageBlitMode::OPAQUE);
-		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
-		images.push_back(image);
+		heroIconIndices.push_back(hero->getIconIndex());
 	}
 
 	int selectedIndex = 0;
@@ -791,9 +788,26 @@ void CTavernWindow::chooseHeroToInvite(CGHeroInstance* selectedHero, const std::
 		selectedIndex = std::distance(heroes.begin(), it);
 	}
 
+	// Load portraits lazily: only visible list items are created, so avoid decoding all of them upfront.
+	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
+	auto imageLoader = [imageCache, heroIconIndices](size_t index) -> std::shared_ptr<IImage>
+	{
+		if(index >= heroIconIndices.size())
+			return nullptr;
+
+		auto it = imageCache->find(static_cast<int32_t>(index));
+		if(it != imageCache->end())
+			return it->second;
+
+		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), heroIconIndices[index], 0, EImageBlitMode::OPAQUE);
+		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
+		(*imageCache)[static_cast<int32_t>(index)] = image;
+		return image;
+	};
+
 	auto window = std::make_shared<CObjectListWindow>(texts, nullptr, LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), [onChoose, heroes](int index){
 		onChoose(heroes.at(index));
-	}, selectedIndex, images, true, false);
+	}, selectedIndex, imageLoader, true, false);
 	window->onPopup = [heroes](int index) {
 		ENGINE->windows().createAndPushWindow<CRClickPopupInt>(std::make_shared<CHeroWindow>(heroes.at(index)));
 	};
@@ -1751,8 +1765,20 @@ CObjectListWindow::CItem::CItem(CObjectListWindow * _parent, size_t _id, std::st
 
 	auto it = std::find(parent->items.begin(), parent->items.end(), parent->itemsVisible[index]);
 	int imgIndex = (it != parent->items.end()) ? std::distance(parent->items.begin(), it) : -1;
-	if(imgIndex >= 0 && imgIndex < parent->images.size() && parent->images[imgIndex])
-		icon = std::make_shared<CPicture>(parent->images[imgIndex], Point(1,1));
+
+	std::shared_ptr<IImage> image;
+	if(parent->imageLoader)
+	{
+		if(imgIndex >= 0)
+			image = parent->imageLoader(imgIndex);
+	}
+	else if(imgIndex >= 0 && imgIndex < parent->images.size())
+	{
+		image = parent->images[imgIndex];
+	}
+
+	if(image)
+		icon = std::make_shared<CPicture>(image, Point(1,1));
 
 	border = std::make_shared<CPicture>(ImagePath::builtin("TPGATES"));
 	pos = border->pos;
@@ -1828,6 +1854,30 @@ CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, st
 	onSelect(Callback),
 	selected(initialSelection),
 	images(images)
+{
+	OBJECT_CONSTRUCTION;
+
+	addUsedEvents(KEYBOARD);
+
+	items.reserve(_items.size());
+
+	for(size_t i = 0; i < _items.size(); i++)
+	{
+		std::string objectName = _items[i];
+		trimTextIfTooWide(objectName, true);
+		items.emplace_back(static_cast<int>(i), objectName);
+	}
+	itemsVisible = items;
+
+	init(titleWidget_, _title, _descr, searchBoxEnabled, blue);
+	list->scrollTo(std::min(static_cast<int>(initialSelection + 4), static_cast<int>(items.size() - 1))); // 4 is for centering (list have 9 elements)
+}
+
+CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled, bool blue)
+	: CWindowObject(PLAYER_COLORED, ImagePath::builtin(blue ? "TownPortalBackgroundBlue" : "TPGATE")),
+	onSelect(Callback),
+	selected(initialSelection),
+	imageLoader(imageLoader)
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -754,8 +754,7 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 
 std::function<std::shared_ptr<IImage>(size_t)> CObjectListWindow::makeLazyHeroPortraitLoader(std::vector<int32_t> iconIndices)
 {
-	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
-	return [imageCache, iconIndices = std::move(iconIndices)](size_t index) -> std::shared_ptr<IImage>
+	return [iconIndices = std::move(iconIndices)](size_t index) -> std::shared_ptr<IImage>
 	{
 		if(index >= iconIndices.size())
 			return nullptr;
@@ -764,13 +763,8 @@ std::function<std::shared_ptr<IImage>(size_t)> CObjectListWindow::makeLazyHeroPo
 		if(iconIndex < 0)
 			return nullptr;
 
-		auto it = imageCache->find(static_cast<int32_t>(index));
-		if(it != imageCache->end())
-			return it->second;
-
 		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), iconIndex, 0, EImageBlitMode::OPAQUE);
 		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
-		(*imageCache)[static_cast<int32_t>(index)] = image;
 		return image;
 	};
 }

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -752,6 +752,29 @@ CTavernWindow::CTavernWindow(const CGObjectInstance * TavernObj, const std::func
 	addInvite();
 }
 
+std::function<std::shared_ptr<IImage>(size_t)> CObjectListWindow::makeLazyHeroPortraitLoader(std::vector<int32_t> iconIndices)
+{
+	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
+	return [imageCache, iconIndices = std::move(iconIndices)](size_t index) -> std::shared_ptr<IImage>
+	{
+		if(index >= iconIndices.size())
+			return nullptr;
+
+		const int32_t iconIndex = iconIndices[index];
+		if(iconIndex < 0)
+			return nullptr;
+
+		auto it = imageCache->find(static_cast<int32_t>(index));
+		if(it != imageCache->end())
+			return it->second;
+
+		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), iconIndex, 0, EImageBlitMode::OPAQUE);
+		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
+		(*imageCache)[static_cast<int32_t>(index)] = image;
+		return image;
+	};
+}
+
 void CTavernWindow::chooseHeroToInvite(CGHeroInstance* selectedHero, const std::map<HeroTypeID, CGHeroInstance*> & inviteableHeroes, const std::function<void(CGHeroInstance*)> & onChoose)
 {
 	auto comp = [](const HeroTypeID& a, const HeroTypeID& b)
@@ -789,21 +812,7 @@ void CTavernWindow::chooseHeroToInvite(CGHeroInstance* selectedHero, const std::
 	}
 
 	// Load portraits lazily: only visible list items are created, so avoid decoding all of them upfront.
-	auto imageCache = std::make_shared<std::map<int32_t, std::shared_ptr<IImage>>>();
-	auto imageLoader = [imageCache, heroIconIndices](size_t index) -> std::shared_ptr<IImage>
-	{
-		if(index >= heroIconIndices.size())
-			return nullptr;
-
-		auto it = imageCache->find(static_cast<int32_t>(index));
-		if(it != imageCache->end())
-			return it->second;
-
-		auto image = ENGINE->renderHandler().loadImage(AnimationPath::builtin("PortraitsSmall"), heroIconIndices[index], 0, EImageBlitMode::OPAQUE);
-		image->scaleTo(Point(35, 23), EScalingAlgorithm::NEAREST);
-		(*imageCache)[static_cast<int32_t>(index)] = image;
-		return image;
-	};
+	auto imageLoader = CObjectListWindow::makeLazyHeroPortraitLoader(std::move(heroIconIndices));
 
 	auto window = std::make_shared<CObjectListWindow>(texts, nullptr, LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), LIBRARY->generaltexth->translate("vcmi.lobby.battleOnlyModeHeroSelect"), [onChoose, heroes](int index){
 		onChoose(heroes.at(index));

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1859,11 +1859,11 @@ CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, st
 {
 }
 
-CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled, bool blue)
+CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, const std::function<std::shared_ptr<IImage>(size_t)> & _imageLoader, bool searchBoxEnabled, bool blue)
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin(blue ? "TownPortalBackgroundBlue" : "TPGATE")),
 	onSelect(Callback),
 	selected(initialSelection),
-	imageLoader(imageLoader)
+	imageLoader(_imageLoader)
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1853,27 +1853,10 @@ CObjectListWindow::CObjectListWindow(const std::vector<int> & _items, std::share
 }
 
 CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::vector<std::shared_ptr<IImage>> images, bool searchBoxEnabled, bool blue)
-	: CWindowObject(PLAYER_COLORED, ImagePath::builtin(blue ? "TownPortalBackgroundBlue" : "TPGATE")),
-	onSelect(Callback),
-	selected(initialSelection),
-	images(images)
+	: CObjectListWindow(_items, titleWidget_, _title, _descr, Callback, initialSelection,
+		[images](size_t index) { return index < images.size() ? images[index] : std::shared_ptr<IImage>(); },
+		searchBoxEnabled, blue)
 {
-	OBJECT_CONSTRUCTION;
-
-	addUsedEvents(KEYBOARD);
-
-	items.reserve(_items.size());
-
-	for(size_t i = 0; i < _items.size(); i++)
-	{
-		std::string objectName = _items[i];
-		trimTextIfTooWide(objectName, true);
-		items.emplace_back(static_cast<int>(i), objectName);
-	}
-	itemsVisible = items;
-
-	init(titleWidget_, _title, _descr, searchBoxEnabled, blue);
-	list->scrollTo(std::min(static_cast<int>(initialSelection + 4), static_cast<int>(items.size() - 1))); // 4 is for centering (list have 9 elements)
 }
 
 CObjectListWindow::CObjectListWindow(const std::vector<std::string> & _items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled, bool blue)

--- a/client/windows/GUIClasses.cpp
+++ b/client/windows/GUIClasses.cpp
@@ -1770,15 +1770,8 @@ CObjectListWindow::CItem::CItem(CObjectListWindow * _parent, size_t _id, std::st
 	int imgIndex = (it != parent->items.end()) ? std::distance(parent->items.begin(), it) : -1;
 
 	std::shared_ptr<IImage> image;
-	if(parent->imageLoader)
-	{
-		if(imgIndex >= 0)
-			image = parent->imageLoader(imgIndex);
-	}
-	else if(imgIndex >= 0 && imgIndex < parent->images.size())
-	{
-		image = parent->images[imgIndex];
-	}
+	if(parent->imageLoader && imgIndex >= 0)
+		image = parent->imageLoader(imgIndex);
 
 	if(image)
 		icon = std::make_shared<CPicture>(image, Point(1,1));
@@ -1832,7 +1825,7 @@ CObjectListWindow::CObjectListWindow(const std::vector<int> & _items, std::share
 	: CWindowObject(PLAYER_COLORED, ImagePath::builtin(blue ? "TownPortalBackgroundBlue" : "TPGATE")),
 	onSelect(Callback),
 	selected(initialSelection),
-	images(images)
+	imageLoader([images](size_t index) { return index < images.size() ? images[index] : std::shared_ptr<IImage>(); })
 {
 	OBJECT_CONSTRUCTION;
 

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -233,6 +233,8 @@ public:
 	CObjectListWindow(const std::vector<int> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
 	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
 	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled = false, bool blue = false);
+	/// Creates a lazy loader that loads and caches small hero portraits (PortraitsSmall) on demand.
+	static std::function<std::shared_ptr<IImage>(size_t)> makeLazyHeroPortraitLoader(std::vector<int32_t> iconIndices);
 	void setControllerActionPrompts(const std::string & acceptActionText, const std::string & cancelActionText);
 	void activate() override;
 	void deactivate() override;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -201,6 +201,7 @@ class CObjectListWindow : public CWindowObject
 	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CLabel> descr;
 	std::vector<std::shared_ptr<IImage>> images;
+	std::function<std::shared_ptr<IImage>(size_t)> imageLoader;
 
 	std::shared_ptr<CListBox> list;
 	std::shared_ptr<CControllerActionButton> ok;
@@ -231,6 +232,7 @@ public:
 	///item names will be taken from map objects
 	CObjectListWindow(const std::vector<int> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
 	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
+	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled = false, bool blue = false);
 	void setControllerActionPrompts(const std::string & acceptActionText, const std::string & cancelActionText);
 	void activate() override;
 	void deactivate() override;

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -232,7 +232,7 @@ public:
 	///item names will be taken from map objects
 	CObjectListWindow(const std::vector<int> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
 	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection = 0, std::vector<std::shared_ptr<IImage>> images = {}, bool searchBoxEnabled = false, bool blue = false);
-	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, std::function<std::shared_ptr<IImage>(size_t)> imageLoader, bool searchBoxEnabled = false, bool blue = false);
+	CObjectListWindow(const std::vector<std::string> &_items, std::shared_ptr<CIntObject> titleWidget_, std::string _title, std::string _descr, std::function<void(int)> Callback, size_t initialSelection, const std::function<std::shared_ptr<IImage>(size_t)> & _imageLoader, bool searchBoxEnabled = false, bool blue = false);
 	/// Creates a lazy loader that loads and caches small hero portraits (PortraitsSmall) on demand.
 	static std::function<std::shared_ptr<IImage>(size_t)> makeLazyHeroPortraitLoader(std::vector<int32_t> iconIndices);
 	void setControllerActionPrompts(const std::string & acceptActionText, const std::string & cancelActionText);

--- a/client/windows/GUIClasses.h
+++ b/client/windows/GUIClasses.h
@@ -200,7 +200,6 @@ class CObjectListWindow : public CWindowObject
 	std::shared_ptr<CIntObject> titleWidget;
 	std::shared_ptr<CLabel> title;
 	std::shared_ptr<CLabel> descr;
-	std::vector<std::shared_ptr<IImage>> images;
 	std::function<std::shared_ptr<IImage>(size_t)> imageLoader;
 
 	std::shared_ptr<CListBox> list;


### PR DESCRIPTION
## Problem

Opening the hero selection lists (tavern "invite hero" and battle-only mode hero selector) was slow. The code eagerly loaded and scaled every hero's portrait up front, even though the list only shows a handful of items at a time. With large mod sets this means decoding thousands of images on open.

## Change

- Load portraits lazily: an image is only loaded when its list item is actually created, and results are cached.
- Add an optional `imageLoader` callback to `CObjectListWindow`; existing callers that pass a pre-built `images` vector keep working unchanged.
- Apply lazy loading to `CTavernWindow::chooseHeroToInvite` and `BattleOnlyModeHeroSelector::selectHero`.

## Result

The list opens almost instantly and images load incrementally as the user scrolls.