### PR TITLE
Fix map editor saving spell restrictions with row indices

### DIFF
--- a/mapeditor/mapsettings/mapsettings.cpp
+++ b/mapeditor/mapsettings/mapsettings.cpp
@@ -90,7 +90,7 @@ void MapSettings::on_pushButton_clicked()
 		{
 			auto * item = widget->item(i);
 			if (item->checkState() == Qt::Checked)
-				arr.emplace(i);
+				arr.emplace(item->data(Qt::UserRole).toInt());
 		}
 	};
 	


### PR DESCRIPTION
## Summary
- `MapSettings::on_pushButton_clicked()` saved the "Allowed Spells" (and abilities/artifacts) checklist by inserting the **row index** of each checked item instead of its actual identifier (`item->data(Qt::UserRole)`), which is already used correctly when the dialog populates checkbox state on open.
- The spell checklist only lists "common" hero spells (`isCommonHeroSpell()`), skipping creature-only/special spells (e.g. Titan's Lightning Bolt). Every such skip shifts all subsequent rows out of alignment with the real spell IDs, so saving wrote the wrong spell into `allowedSpells`.
- Concretely: with the default HotA spell list, Titan's Lightning Bolt (id 57) is skipped, so Summon Fire/Earth/Water Elemental (ids 66-68) end up on rows 65-67, and Summon Air Elemental (id 69) ends up on row 68 — the last row that exists. Any save wrote row-number values, so id 69 could never be produced (max row index is 68), permanently and deterministically dropping Summon Air Elemental from `allowedSpells` for any map saved through this dialog. Ids 66-68 happened to survive only by coincidence, since the shifted row values still landed on other valid, checked spell IDs.

## Fix
Use the stored real identifier instead of the row position when saving.

## Test plan
- [x] Rebuilt `vcmieditor`, confirmed clean compile
- [x] Instrumented spell loading to confirm the exact row/ID mismatch described above
- [ ] Reviewer: open Map Specifications on an existing map, verify allowed-spell checkbox state round-trips correctly after Save