### PR TITLE
[Map Editor] Fix timed event resources and support capture all mines victory condition

### DIFF
--- a/mapeditor/mapsettings/eventsettings.cpp
+++ b/mapeditor/mapsettings/eventsettings.cpp
@@ -16,6 +16,7 @@
 #include "../../lib/constants/StringConstants.h"
 #include "../../lib/GameLibrary.h"
 #include "../../lib/entities/ResourceTypeHandler.h"
+#include "../../lib/modding/ModScope.h"
 #include "../translator.h"
 
 QString toQString(const PlayerColor & player)
@@ -54,6 +55,7 @@ TResources resourcesFromVariant(const QVariant & v)
 	JsonNode vJson;
 	for(auto r : v.toMap().keys())
 		vJson[r.toStdString()].Integer() = v.toMap().value(r).toInt();
+	vJson.setModScope(ModScope::scopeMap());
 	ResourceSet res;
 	res.resolveFromJson(vJson);
 	return res;

--- a/mapeditor/mapsettings/victoryconditions.cpp
+++ b/mapeditor/mapsettings/victoryconditions.cpp
@@ -38,7 +38,7 @@ void VictoryConditions::initialize(MapController & c)
 	ui->victoryMessageEdit->setText(QString::fromStdString(controller->map()->victoryMessage.toString(&Translator::instance())));
 
 	//victory conditions
-	const std::array<std::string, 9> conditionStringsWin = {
+	const std::array<std::string, 10> conditionStringsWin = {
 		QT_TR_NOOP("No special victory"),
 		QT_TR_NOOP("Capture artifact"),
 		QT_TR_NOOP("Hire creatures"),
@@ -47,7 +47,8 @@ void VictoryConditions::initialize(MapController & c)
 		QT_TR_NOOP("Capture town"),
 		QT_TR_NOOP("Defeat hero"),
 		QT_TR_NOOP("Transport artifact"),
-		QT_TR_NOOP("Kill monster")
+		QT_TR_NOOP("Kill monster"),
+		QT_TR_NOOP("Capture all mines")
 	};
 
 	for(auto & s : conditionStringsWin)
@@ -122,9 +123,14 @@ void VictoryConditions::initialize(MapController & c)
 
 							case EventCondition::CONTROL:
 							case EventCondition::CONTROL_CURRENT: {
+							auto mapObject = MapObjectID::decode(json["objectType"].String());
+							if(mapObject == Obj::MINE)
+							{
+								ui->victoryComboBox->setCurrentIndex(9);
+								break;
+							}
 							ui->victoryComboBox->setCurrentIndex(5);
 							assert(victoryTypeWidget);
-							auto mapObject = MapObjectID::decode(json["objectType"].String());
 							if(mapObject == Obj::TOWN)
 							{
 								int townIdx = getObjectByPos<const CGTownInstance>(*controller->map(), posFromJson(json["position"]));
@@ -134,7 +140,7 @@ void VictoryConditions::initialize(MapController & c)
 									victoryTypeWidget->setCurrentIndex(idx);
 								}
 							}
-							//TODO: support control other objects (dwellings, mines)
+							//TODO: support control other objects (dwellings)
 							break;
 						}
 
@@ -323,6 +329,17 @@ void VictoryConditions::update()
 				specialVictory.effect.toOtherMessage.appendTextID("core.genrltxt.287");
 				specialVictory.onFulfill.appendTextID("core.genrltxt.286");
 				specialVictory.trigger = EventExpression(cond);
+				break;
+			}
+
+			case 8: {
+				EventCondition cond(EventCondition::CONTROL_CURRENT);
+				cond.objectType = Obj(Obj::MINE);
+				specialVictory.effect.toOtherMessage.appendTextID("core.genrltxt.291");
+				specialVictory.onFulfill.appendTextID("core.genrltxt.290");
+				specialVictory.trigger = EventExpression(cond);
+				controller->map()->victoryIconIndex = 9;
+				controller->map()->victoryMessage = MetaString::createFromTextID("core.vcdesc.10");
 				break;
 			}
 


### PR DESCRIPTION
Found while adapting a H3M map for testing changes on another branch:

  - Clicking OK after changing only the map name triggered an assertion because timed-event resources had an empty mod scope.
  - Assigning players to two teams exposed another issue: unsupported special victory conditions, such as “capture all mines,” were silently converted to “capture town,” eventually causing the client to crash.

  Event resources now use the map scope. Unsupported victory conditions are clearly marked in the editor and preserved unchanged.