### PR TITLE
one finger zoom

### DIFF
--- a/clientsdl2/events/InputSourceTouch.cpp
+++ b/clientsdl2/events/InputSourceTouch.cpp
@@ -33,7 +33,7 @@
 #include <SDL_timer.h>
 
 InputSourceTouch::InputSourceTouch()
-	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0)
+	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0), doubleTapZoomCandidate(false)
 {
 	params.useRelativeMode = settings["general"]["userRelativePointer"].Bool();
 	params.relativeModeSpeedFactor = settings["general"]["relativePointerSpeedMultiplier"].Float();
@@ -99,7 +99,10 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
 			{
 				ENGINE->events().dispatchTouchPress(lastTapPosition, false, params.touchToleranceDistance);
-				state = state == TouchState::TAP_DOWN_SHORT ? TouchState::TAP_DOWN_PANNING : TouchState::TAP_DOWN_PANNING_POPUP;
+				if (state == TouchState::TAP_DOWN_SHORT)
+					state = doubleTapZoomCandidate ? TouchState::TAP_DOWN_ZOOM : TouchState::TAP_DOWN_PANNING;
+				else
+					state = TouchState::TAP_DOWN_PANNING_POPUP;
 				ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			}
 			break;
@@ -113,6 +116,11 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 		case TouchState::TAP_DOWN_DOUBLE:
 		{
 			emitPinchEvent(tfinger);
+			break;
+		}
+		case TouchState::TAP_DOWN_ZOOM:
+		{
+			emitOneFingerZoomEvent(tfinger);
 			break;
 		}
 		case TouchState::TAP_DOWN_LONG:
@@ -162,6 +170,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		case TouchState::IDLE:
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
+			doubleTapZoomCandidate = tfinger.timestamp - lastLeftClickTimeTicks < params.doubleTouchTimeMilliseconds && (lastTapPosition - lastLeftClickPosition).length() < params.doubleTouchToleranceDistance;
 			ENGINE->input().setCursorPosition(lastTapPosition);
 			ENGINE->events().dispatchTouchPress(lastTapPosition, true, params.touchToleranceDistance);
 			state = TouchState::TAP_DOWN_SHORT;
@@ -175,6 +184,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 			break;
 		}
 		case TouchState::TAP_DOWN_PANNING:
+		case TouchState::TAP_DOWN_ZOOM:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
 			state = TouchState::TAP_DOWN_DOUBLE;
@@ -246,6 +256,15 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 			state = state == TouchState::TAP_DOWN_PANNING ? TouchState::IDLE : TouchState::TAP_DOWN_LONG_AWAIT;
 			break;
 		}
+		case TouchState::TAP_DOWN_ZOOM:
+		{
+			ENGINE->events().dispatchGesturePanningEnded(lastTapPosition, convertTouchToMouse(tfinger));
+			ENGINE->events().dispatchTouchPress(lastTapPosition, false, params.touchToleranceDistance);
+			// prevent the tap that ended the zoom from starting another double tap
+			lastLeftClickTimeTicks = 0;
+			state = TouchState::IDLE;
+			break;
+		}
 		case TouchState::TAP_DOWN_DOUBLE:
 		{
 			if (SDL_GetNumTouchFingers(tfinger.touchId) == 1)
@@ -284,7 +303,7 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 
 void InputSourceTouch::handleUpdate()
 {
-	if ( state == TouchState::TAP_DOWN_SHORT)
+	if ( state == TouchState::TAP_DOWN_SHORT && !doubleTapZoomCandidate)
 	{
 		uint32_t currentTime = SDL_GetTicks();
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
@@ -370,6 +389,16 @@ void InputSourceTouch::emitPinchEvent(const SDL_TouchFingerEvent & tfinger)
 
 	if (distanceOld > params.pinchSensitivityThreshold)
 		ENGINE->events().dispatchGesturePinch(lastTapPosition, distanceNew / distanceOld);
+}
+
+void InputSourceTouch::emitOneFingerZoomEvent(const SDL_TouchFingerEvent & tfinger)
+{
+	// consume accumulated motion, otherwise sub-pixel remainders would be applied more than once
+	float distance = motionAccumulatedY[tfinger.fingerId];
+	motionAccumulatedY[tfinger.fingerId] = 0;
+
+	// dragging down zooms in, dragging up zooms out
+	ENGINE->events().dispatchGesturePinch(lastTapPosition, std::pow(2.0, distance / params.doubleTapZoomScreenFraction));
 }
 
 void InputSourceTouch::hapticFeedback() {

--- a/clientsdl2/events/InputSourceTouch.h
+++ b/clientsdl2/events/InputSourceTouch.h
@@ -58,6 +58,12 @@ enum class TouchState
 	// UP -> transition to TAP_DOWN
 	TAP_DOWN_DOUBLE,
 
+	// single finger is moving after a double tap, zooming instead of panning
+	// DOWN -> transition to TAP_DOWN_DOUBLE
+	// MOTION -> emit pinch event
+	// UP -> transition to IDLE
+	TAP_DOWN_ZOOM,
+
 	// single finger is down for long period of time
 	// DOWN -> ignored
 	// MOTION -> ignored
@@ -91,6 +97,9 @@ struct TouchInputParameters
 	/// gesture will be qualified as pinch if distance between fingers is at least specified here
 	uint32_t pinchSensitivityThreshold = 10;
 
+	/// vertical drag distance that doubles the zoom during one finger zoom, as fraction of screen height
+	double doubleTapZoomScreenFraction = 0.25;
+
 	/// touch event will trigger clicking of elements up to X pixels away from actual touch position
 	uint32_t touchToleranceDistance = 20;
 
@@ -111,6 +120,9 @@ class InputSourceTouch
 	Point lastLeftClickPosition;
 	int numTouchFingers;
 
+	/// set if current touch is the second tap of a double tap, which allows one finger zoom instead of panning
+	bool doubleTapZoomCandidate;
+
 	std::map<SDL_FingerID, float> motionAccumulatedX;
 	std::map<SDL_FingerID, float> motionAccumulatedY;
 
@@ -119,6 +131,7 @@ class InputSourceTouch
 
 	void emitPanningEvent(const SDL_TouchFingerEvent & tfinger);
 	void emitPinchEvent(const SDL_TouchFingerEvent & tfinger);
+	void emitOneFingerZoomEvent(const SDL_TouchFingerEvent & tfinger);
 
 public:
 	InputSourceTouch();

--- a/clientsdl3/events/InputSourceTouch.cpp
+++ b/clientsdl3/events/InputSourceTouch.cpp
@@ -48,7 +48,7 @@ static uint32_t touchEventTimeMs(const SDL_TouchFingerEvent & tfinger)
 }
 
 InputSourceTouch::InputSourceTouch()
-	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0)
+	: lastTapTimeTicks(0), lastLeftClickTimeTicks(0), numTouchFingers(0), doubleTapZoomCandidate(false)
 {
 	params.useRelativeMode = settings["general"]["userRelativePointer"].Bool();
 	params.relativeModeSpeedFactor = settings["general"]["relativePointerSpeedMultiplier"].Float();
@@ -118,7 +118,10 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 			if ( std::abs(distance.x) > params.panningSensitivityThreshold || std::abs(distance.y) > params.panningSensitivityThreshold)
 			{
 				ENGINE->events().dispatchTouchPress(lastTapPosition, false, params.touchToleranceDistance);
-				state = state == TouchState::TAP_DOWN_SHORT ? TouchState::TAP_DOWN_PANNING : TouchState::TAP_DOWN_PANNING_POPUP;
+				if (state == TouchState::TAP_DOWN_SHORT)
+					state = doubleTapZoomCandidate ? TouchState::TAP_DOWN_ZOOM : TouchState::TAP_DOWN_PANNING;
+				else
+					state = TouchState::TAP_DOWN_PANNING_POPUP;
 				ENGINE->events().dispatchGesturePanningStarted(lastTapPosition);
 			}
 			break;
@@ -132,6 +135,11 @@ void InputSourceTouch::handleEventFingerMotion(const SDL_TouchFingerEvent & tfin
 		case TouchState::TAP_DOWN_DOUBLE:
 		{
 			emitPinchEvent(tfinger);
+			break;
+		}
+		case TouchState::TAP_DOWN_ZOOM:
+		{
+			emitOneFingerZoomEvent(tfinger);
 			break;
 		}
 		case TouchState::TAP_DOWN_LONG:
@@ -181,6 +189,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 		case TouchState::IDLE:
 		{
 			lastTapPosition = convertTouchToMouse(tfinger);
+			doubleTapZoomCandidate = touchEventTimeMs(tfinger) - lastLeftClickTimeTicks < params.doubleTouchTimeMilliseconds && (lastTapPosition - lastLeftClickPosition).length() < params.doubleTouchToleranceDistance;
 			ENGINE->input().setCursorPosition(lastTapPosition);
 			ENGINE->events().dispatchTouchPress(lastTapPosition, true, params.touchToleranceDistance);
 			state = TouchState::TAP_DOWN_SHORT;
@@ -194,6 +203,7 @@ void InputSourceTouch::handleEventFingerDown(const SDL_TouchFingerEvent & tfinge
 			break;
 		}
 		case TouchState::TAP_DOWN_PANNING:
+		case TouchState::TAP_DOWN_ZOOM:
 		{
 			ENGINE->input().setCursorPosition(convertTouchToMouse(tfinger));
 			state = TouchState::TAP_DOWN_DOUBLE;
@@ -265,6 +275,15 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 			state = state == TouchState::TAP_DOWN_PANNING ? TouchState::IDLE : TouchState::TAP_DOWN_LONG_AWAIT;
 			break;
 		}
+		case TouchState::TAP_DOWN_ZOOM:
+		{
+			ENGINE->events().dispatchGesturePanningEnded(lastTapPosition, convertTouchToMouse(tfinger));
+			ENGINE->events().dispatchTouchPress(lastTapPosition, false, params.touchToleranceDistance);
+			// prevent the tap that ended the zoom from starting another double tap
+			lastLeftClickTimeTicks = 0;
+			state = TouchState::IDLE;
+			break;
+		}
 		case TouchState::TAP_DOWN_DOUBLE:
 		{
 			if (countTouchFingers(tfinger.touchID) == 1)
@@ -303,7 +322,7 @@ void InputSourceTouch::handleEventFingerUp(const SDL_TouchFingerEvent & tfinger)
 
 void InputSourceTouch::handleUpdate()
 {
-	if ( state == TouchState::TAP_DOWN_SHORT)
+	if ( state == TouchState::TAP_DOWN_SHORT && !doubleTapZoomCandidate)
 	{
 		uint32_t currentTime = static_cast<uint32_t>(SDL_GetTicks());
 		if (currentTime > lastTapTimeTicks + params.longTouchTimeMilliseconds)
@@ -397,6 +416,16 @@ void InputSourceTouch::emitPinchEvent(const SDL_TouchFingerEvent & tfinger)
 
 	if (distanceOld > params.pinchSensitivityThreshold)
 		ENGINE->events().dispatchGesturePinch(lastTapPosition, distanceNew / distanceOld);
+}
+
+void InputSourceTouch::emitOneFingerZoomEvent(const SDL_TouchFingerEvent & tfinger)
+{
+	// consume accumulated motion, otherwise sub-pixel remainders would be applied more than once
+	float distance = motionAccumulatedY[tfinger.fingerID];
+	motionAccumulatedY[tfinger.fingerID] = 0;
+
+	// dragging down zooms in, dragging up zooms out
+	ENGINE->events().dispatchGesturePinch(lastTapPosition, std::pow(2.0, distance / params.doubleTapZoomScreenFraction));
 }
 
 void InputSourceTouch::hapticFeedback() {

--- a/clientsdl3/events/InputSourceTouch.h
+++ b/clientsdl3/events/InputSourceTouch.h
@@ -58,6 +58,12 @@ enum class TouchState
 	// UP -> transition to TAP_DOWN
 	TAP_DOWN_DOUBLE,
 
+	// single finger is moving after a double tap, zooming instead of panning
+	// DOWN -> transition to TAP_DOWN_DOUBLE
+	// MOTION -> emit pinch event
+	// UP -> transition to IDLE
+	TAP_DOWN_ZOOM,
+
 	// single finger is down for long period of time
 	// DOWN -> ignored
 	// MOTION -> ignored
@@ -91,6 +97,9 @@ struct TouchInputParameters
 	/// gesture will be qualified as pinch if distance between fingers is at least specified here
 	uint32_t pinchSensitivityThreshold = 10;
 
+	/// vertical drag distance that doubles the zoom during one finger zoom, as fraction of screen height
+	double doubleTapZoomScreenFraction = 0.25;
+
 	/// touch event will trigger clicking of elements up to X pixels away from actual touch position
 	uint32_t touchToleranceDistance = 20;
 
@@ -111,6 +120,9 @@ class InputSourceTouch
 	Point lastLeftClickPosition;
 	int numTouchFingers;
 
+	/// set if current touch is the second tap of a double tap, which allows one finger zoom instead of panning
+	bool doubleTapZoomCandidate;
+
 	std::map<SDL_FingerID, float> motionAccumulatedX;
 	std::map<SDL_FingerID, float> motionAccumulatedY;
 
@@ -119,6 +131,7 @@ class InputSourceTouch
 
 	void emitPanningEvent(const SDL_TouchFingerEvent & tfinger);
 	void emitPinchEvent(const SDL_TouchFingerEvent & tfinger);
+	void emitOneFingerZoomEvent(const SDL_TouchFingerEvent & tfinger);
 
 public:
 	InputSourceTouch();


### PR DESCRIPTION
Same gesture as google maps. Double tap and hold second tap - then move up and down for zoom.

Fixes #5606 (zoom with touch or stylus).