### PR TITLE
Fix crash when moving a hero toward the top-left map tile

### DIFF
--- a/client/HeroMovementController.cpp
+++ b/client/HeroMovementController.cpp
@@ -207,6 +207,9 @@ void HeroMovementController::onTryMoveHero(const CGHeroInstance * hero, const Tr
 			{ 7, 6, 5 }
 		};
 
+		assert(posOffset.x >= 0 && posOffset.x < 3 && posOffset.y >= 0 && posOffset.y < 3);
+		if(posOffset.x < 0 || posOffset.x >= 3 || posOffset.y < 0 || posOffset.y >= 3)
+			return;
 		//FIXME: better handling of this case without const_cast
 		const_cast<CGHeroInstance *>(hero)->moveDir = dirLookup[posOffset.y][posOffset.x];
 	}

--- a/lib/networkPacks/PacksForClient.h
+++ b/lib/networkPacks/PacksForClient.h
@@ -714,7 +714,7 @@ struct DLL_LINKAGE TryMoveHero : public CPackForClient
 	/// Tiles that were revealed by this move
 	FowTilesType fowRevealed;
 	/// If hero moves on guarded tile, this field will be set to visitable pos of attacked wandering monster
-	int3 attackedFrom;
+	int3 attackedFrom = int3(-1);
 
 	void visitTyped(ICPackVisitor & visitor) override;
 


### PR DESCRIPTION
An unset attacker position was mistaken for a path target at (0,0,0), causing an out-of-bounds direction lookup.

Fixes #7811 #7079 #6623:
- #7811 
- #7079
- #6623