### PR TITLE
Fix campaign completion after post-battle level-up

### DIFF
--- a/lib/gameState/CGameState.cpp
+++ b/lib/gameState/CGameState.cpp
@@ -1494,6 +1494,11 @@ PlayerColor CGameState::checkForStandardWin() const
 				//current candidate has enemy remaining in game -> no vicotry
 				return PlayerColor::NEUTRAL;
 			}
+			else if(!players.at(supposedWinner).human && elem.second.human)
+			{
+				//prefer a human winner over an AI ally from the same surviving team
+				supposedWinner = elem.second.color;
+			}
 		}
 	}
 

--- a/server/CGameHandler.cpp
+++ b/server/CGameHandler.cpp
@@ -3837,11 +3837,43 @@ void CGameHandler::checkVictoryLossConditionsForAll()
 	checkVictoryLossConditions(playerColors);
 }
 
+bool CGameHandler::hasPendingLevelUpQuery() const
+{
+	const QueriesProcessor & queryProcessor = *queries;
+	for(const auto & query : queryProcessor.allQueries())
+	{
+		const auto type = query->getType();
+		if(type == QueryType::HeroLevelUpDialog || type == QueryType::CommanderLevelUpDialog)
+			return true;
+	}
+
+	return false;
+}
+
+void CGameHandler::resumeDeferredVictoryLossChecks()
+{
+	if(playersWithDeferredVictoryLossChecks.empty() || hasPendingLevelUpQuery())
+		return;
+
+	auto playersToCheck = std::move(playersWithDeferredVictoryLossChecks);
+	playersWithDeferredVictoryLossChecks.clear();
+	checkVictoryLossConditions(playersToCheck);
+}
+
 void CGameHandler::checkVictoryLossConditionsForPlayer(PlayerColor player)
 {
 	const PlayerState * p = gameInfo().getPlayerState(player);
 
-	if(!p || p->status != EPlayerStatus::INGAME) return;
+	if(!p || p->status != EPlayerStatus::INGAME)
+		return;
+
+	if(hasPendingLevelUpQuery())
+	{
+		playersWithDeferredVictoryLossChecks.insert(player);
+		return;
+	}
+
+	playersWithDeferredVictoryLossChecks.erase(player);
 
 	if(gameState().getMap().battleOnly)
 	{

--- a/server/CGameHandler.h
+++ b/server/CGameHandler.h
@@ -309,11 +309,18 @@ public:
 	void checkVictoryLossConditionsForPlayer(PlayerColor player);
 	void checkVictoryLossConditions(const std::set<PlayerColor> & playerColors);
 	void checkVictoryLossConditionsForAll();
+	void resumeDeferredVictoryLossChecks();
 
 	vstd::RNG & getRandomGenerator() override;
 
 	friend class CVCMIServer;
+
 private:
+	/// Victory processing is deferred globally because one player's loss can make another player
+	/// with a pending level-up win.
+	std::set<PlayerColor> playersWithDeferredVictoryLossChecks;
+
+	bool hasPendingLevelUpQuery() const;
 	void getVictoryLossMessage(PlayerColor player, const EVictoryLossCheckResult & victoryLossCheckResult, InfoWindow & out) const;
 
 	const std::string complainNoCreatures;

--- a/server/queries/MapQueries.cpp
+++ b/server/queries/MapQueries.cpp
@@ -243,11 +243,14 @@ void CHeroLevelUpDialogQuery::onRemoval(PlayerColor color)
 	{
 		logGlobal->trace("Completing hero level-up query. %s gains no secondary skill", hero->getNameTextID());
 		gh->levelUpHero(hero);
-		return;
+	}
+	else
+	{
+		logGlobal->trace("Completing hero level-up query. %s gains skill %d", hero->getNameTextID(), answer.value());
+		gh->levelUpHero(hero, hlu.skills[*answer]);
 	}
 
-	logGlobal->trace("Completing hero level-up query. %s gains skill %d", hero->getNameTextID(), answer.value());
-	gh->levelUpHero(hero, hlu.skills[*answer]);
+	gh->resumeDeferredVictoryLossChecks();
 }
 
 void CHeroLevelUpDialogQuery::onAdded(PlayerColor color)
@@ -312,11 +315,17 @@ void CCommanderLevelUpDialogQuery::onRemoval(PlayerColor color)
 	{
 		logGlobal->trace("Completing commander level-up query. Commander of hero %s gains no skill", hero->getNameTextID());
 		gh->levelUpCommander(hero->getCommander());
-		return;
+	}
+	else
+	{
+		constexpr const char * logMessage =
+			"Completing commander level-up query. "
+			"Commander of hero %s gains skill %s";
+		logGlobal->trace(logMessage, hero->getNameTextID(), answer.value());
+		gh->levelUpCommander(hero->getCommander(), clu.skills[*answer]);
 	}
 
-	logGlobal->trace("Completing commander level-up query. Commander of hero %s gains skill %s", hero->getNameTextID(), answer.value());
-	gh->levelUpCommander(hero->getCommander(), clu.skills[*answer]);
+	gh->resumeDeferredVictoryLossChecks();
 }
 
 void CCommanderLevelUpDialogQuery::onExposure(QueryPtr topQuery)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,7 @@ set(test_SRCS
 		game/HeroRecruitmentTest.cpp
 		game/HeroSecondarySkillsTest.cpp
 		game/MovementCostTest.cpp
+		game/VictoryLossTest.cpp
 
 		json/JsonTests.cpp
 

--- a/test/game/VictoryLossTest.cpp
+++ b/test/game/VictoryLossTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * VictoryLossTest.cpp, part of VCMI engine
+ *
+ * Authors: listed in file AUTHORS in main folder
+ *
+ * License: GNU General Public License v2.0 or later
+ * Full text of license available in license.txt file, in main folder
+ *
+ */
+#include "StdInc.h"
+
+#include <gtest/gtest.h>
+
+#include "../../lib/CPlayerState.h"
+#include "../../lib/gameState/CGameState.h"
+
+namespace
+{
+
+PlayerState & addPlayer(CGameState & gameState, PlayerColor color, TeamID team, bool human)
+{
+	auto & player = gameState.players.try_emplace(color, &gameState).first->second;
+	player.color = color;
+	player.team = team;
+	player.human = human;
+	player.status = EPlayerStatus::INGAME;
+	return player;
+}
+
+}
+
+TEST(VictoryLossTest, standardWinPrefersHumanOverAiAlly)
+{
+	CGameState gameState;
+	const TeamID survivingTeam(0);
+	const PlayerColor aiPlayer(1);
+	const PlayerColor humanPlayer(3);
+
+	addPlayer(gameState, aiPlayer, survivingTeam, false);
+	addPlayer(gameState, humanPlayer, survivingTeam, true);
+
+	EXPECT_EQ(gameState.checkForStandardWin(), humanPlayer);
+}

--- a/test/server/queries/QueriesProcessorTest.cpp
+++ b/test/server/queries/QueriesProcessorTest.cpp
@@ -2,8 +2,9 @@
 
 #include <gtest/gtest.h>
 
-#include "../../../server/queries/CQuery.h"
 #include "../../../server/battles/BattleProcessor.h"
+#include "../../../server/queries/CQuery.h"
+#include "../../../server/queries/MapQueries.h"
 #include "../../../server/queries/QueriesProcessor.h"
 #include "CGameHandler.h"
 
@@ -11,6 +12,7 @@
 #include "mock/TinyH3MBuilder.h"
 #include "mock/TinyMapGameTest.h"
 
+#include "lib/CPlayerState.h"
 #include "lib/battle/BattleInfo.h"
 #include "lib/gameState/CGameState.h"
 #include "lib/mapObjects/CGDwelling.h"
@@ -129,6 +131,10 @@ protected:
 	}
 };
 
+class DeferredVictoryLossTest : public TinyMapGameTest
+{
+};
+
 }
 
 TEST_F(QueriesProcessorTest, topQuery_returnsNullWhenPlayerHasNoQueries)
@@ -161,6 +167,37 @@ TEST_F(NeutralDwellingBattleQueryTest, ownedDwellingUsesNeutralBattleSideWithout
 	ASSERT_EQ(attackerQuery->players.size(), 1);
 	EXPECT_EQ(attackerQuery->players.front(), PlayerColor(0));
 	EXPECT_EQ(gh.queries->topQuery(PlayerColor(1)), nullptr);
+}
+
+TEST_F(DeferredVictoryLossTest, heroLevelUpDefersAnotherPlayersLossUntilQueryIsAnswered)
+{
+	const PlayerColor defeatedPlayer(0);
+	const PlayerColor levelUpPlayer(1);
+	TinyH3M::TinyH3MBuilder builder(EMapFormat::SOD);
+	builder.size(36, false);
+	builder.playerActive(defeatedPlayer);
+	builder.playerActive(levelUpPlayer);
+	builder.hero(int3(5, 5, 0), HeroTypeID(0), levelUpPlayer);
+	startWithMap(std::move(builder));
+
+	auto * hero = findHeroByOwner(levelUpPlayer);
+	ASSERT_NE(hero, nullptr);
+
+	GameHandlerTestServer server(gameState(), levelUpPlayer);
+	CGameHandler gameHandler(server, gameState());
+
+	HeroLevelUp levelUpDialog;
+	levelUpDialog.player = levelUpPlayer;
+	levelUpDialog.heroId = hero->id;
+	auto levelUpQuery = std::make_shared<CHeroLevelUpDialogQuery>(&gameHandler, levelUpDialog, hero);
+	levelUpQuery->setReply(0);
+	gameHandler.queries->addQuery(levelUpQuery);
+
+	gameHandler.checkVictoryLossConditionsForPlayer(defeatedPlayer);
+	EXPECT_EQ(gameState()->getPlayerState(defeatedPlayer)->status, EPlayerStatus::INGAME);
+
+	gameHandler.queries->popIfTop(levelUpQuery);
+	EXPECT_EQ(gameState()->getPlayerState(defeatedPlayer)->status, EPlayerStatus::LOSER);
 }
 
 TEST_F(QueriesProcessorTest, popIfTop_removesTopQuery)


### PR DESCRIPTION
## Summary

- defer victory and loss processing while a hero or commander level-up query is pending
- resume deferred checks after the level-up choice has been applied
- prefer a human player over an AI ally when selecting the surviving team's standard winner

## Problem

In Foolhardy Waywardness, scenario 2, Christian can reach level 15 after the final battle. The server processed campaign victory and shut down the scenario before the level-up query was resolved. This left the level-up dialog open and prevented progression to the next scenario.

With an AI ally, the standard-win calculation could also designate that AI as the player completing the scenario, instead of the human campaign player.

## Testing

- added a regression test proving that a pending hero level-up defers another player's loss until the query is answered
- added a regression test proving that a human is preferred over an AI ally as the standard winner
- built `vcmiclient`, `vcmiserver`, and `vcmitest`
- both new regression tests pass

## Videos
 
 ### Before
 
 [Screencast_20260907_170422.webm](https://github.com/user-attachments/assets/f1c79faa-ef3c-4546-bfa4-7cc265534cbb)

### After

 [Screencast_20260907_170543.webm](https://github.com/user-attachments/assets/9028e9f1-dca3-4446-90b8-f605f586c705)
