### PR TITLE
Keep full precision when writing floats to json

### DIFF
--- a/lib/json/JsonWriter.cpp
+++ b/lib/json/JsonWriter.cpp
@@ -11,6 +11,8 @@
 #include "StdInc.h"
 #include "JsonWriter.h"
 
+#include <limits>
+
 template<typename Iterator>
 void JsonWriter::writeContainer(Iterator begin, Iterator end)
 {
@@ -86,6 +88,30 @@ void JsonWriter::writeString(const std::string & string)
 	out << '\"';
 }
 
+void JsonWriter::writeFloat(double value)
+{
+	// An ostream writes six significant digits by default, which rounds off a value that the parser
+	// read as the double nearest to the number in the file, so reading a file and writing it back
+	// changes what it says. Write the shortest form that reads back as the same double instead.
+	std::string result;
+
+	for(int precision = std::numeric_limits<double>::digits10; precision <= std::numeric_limits<double>::max_digits10; ++precision)
+	{
+		std::ostringstream formatted;
+		formatted << std::setprecision(precision) << value;
+		result = formatted.str();
+
+		std::istringstream reader(result);
+		double readBack = 0;
+		reader >> readBack;
+
+		if(readBack == value)
+			break;
+	}
+
+	out << result;
+}
+
 void JsonWriter::writeNode(const JsonNode & node)
 {
 	bool originalMode = compactMode;
@@ -106,7 +132,7 @@ void JsonWriter::writeNode(const JsonNode & node)
 			break;
 
 		case JsonNode::JsonType::DATA_FLOAT:
-			out << node.Float();
+			writeFloat(node.Float());
 			break;
 
 		case JsonNode::JsonType::DATA_STRING:

--- a/lib/json/JsonWriter.cpp
+++ b/lib/json/JsonWriter.cpp
@@ -88,28 +88,211 @@ void JsonWriter::writeString(const std::string & string)
 	out << '\"';
 }
 
-void JsonWriter::writeFloat(double value)
+namespace
 {
-	// An ostream writes six significant digits by default, which rounds off a value that the parser
-	// read as the double nearest to the number in the file, so reading a file and writing it back
-	// changes what it says. Write the shortest form that reads back as the same double instead.
-	std::string result;
 
-	for(int precision = std::numeric_limits<double>::digits10; precision <= std::numeric_limits<double>::max_digits10; ++precision)
+/// Repeats the arithmetic that JsonParser::extractFloat performs on unsigned number text. The parser
+/// does not hand numbers to strtod: it gathers the digits into an integer mantissa, stops once a
+/// double can no longer hold them and scales what it has by a power of ten. Whether a number that
+/// has been written comes back unchanged depends on this and on nothing else.
+double readNumberBack(const std::string & text)
+{
+	// largest integer a double still holds exactly, as in JsonParser::extractFloat
+	static constexpr si64 maxExactMantissa = 1LL << 53;
+
+	si64 mantissa = 0;
+	int fractionDigits = 0;
+	size_t pos = 0;
+
+	while(pos < text.size() && text[pos] >= '0' && text[pos] <= '9')
 	{
-		std::ostringstream formatted;
-		formatted << std::setprecision(precision) << value;
-		result = formatted.str();
-
-		std::istringstream reader(result);
-		double readBack = 0;
-		reader >> readBack;
-
-		if(readBack == value)
-			break;
+		mantissa = mantissa * 10 + (text[pos] - '0');
+		pos++;
 	}
 
-	out << result;
+	if(pos < text.size() && text[pos] == '.')
+	{
+		pos++;
+
+		while(pos < text.size() && text[pos] >= '0' && text[pos] <= '9')
+		{
+			// once the mantissa is full the parser drops every digit that follows
+			if(mantissa <= (maxExactMantissa - 9) / 10)
+			{
+				mantissa = mantissa * 10 + (text[pos] - '0');
+				fractionDigits++;
+			}
+			pos++;
+		}
+	}
+
+	double result = static_cast<double>(mantissa) / std::pow(10, fractionDigits);
+
+	if(pos < text.size() && text[pos] == 'e')
+	{
+		pos++;
+
+		bool powerNegative = pos < text.size() && text[pos] == '-';
+
+		if(pos < text.size() && (text[pos] == '-' || text[pos] == '+'))
+			pos++;
+
+		double power = 0;
+
+		while(pos < text.size() && text[pos] >= '0' && text[pos] <= '9')
+		{
+			power = power * 10 + (text[pos] - '0');
+			pos++;
+		}
+
+		if(powerNegative)
+			power = -power;
+
+		result *= std::pow(10, power);
+	}
+
+	return result;
+}
+
+/// Writes magnitude without an exponent and with the given number of digits after the decimal point
+std::string formatFixed(double magnitude, int fractionDigits)
+{
+	std::ostringstream formatted;
+	formatted << std::fixed << std::setprecision(fractionDigits) << magnitude;
+	return formatted.str();
+}
+
+/// Rounds magnitude to the given number of significant digits and hands back those digits along with
+/// the exponent that belongs to them: 1234.5678 to three digits gives "123" and 3
+void roundToDigits(double magnitude, int digitCount, std::string & digits, int & exponent)
+{
+	std::ostringstream formatted;
+	formatted << std::scientific << std::setprecision(digitCount - 1) << magnitude;
+	std::string text = formatted.str();
+
+	size_t exponentAt = text.find('e');
+	exponent = std::stoi(text.substr(exponentAt + 1));
+
+	digits.clear();
+	for(size_t i = 0; i < exponentAt; ++i)
+	{
+		if(text[i] >= '0' && text[i] <= '9')
+			digits += text[i];
+	}
+}
+
+/// Writes the digits with the decimal point after integerDigits of them and the power of ten that
+/// puts the number back where it belongs: "123", 3, 1 gives "1.23e2"
+std::string formatDigits(const std::string & digits, int exponent, int integerDigits)
+{
+	int digitCount = static_cast<int>(digits.size());
+	std::string text;
+
+	if(integerDigits >= digitCount)
+		text = digits + std::string(integerDigits - digitCount, '0');
+	else if(integerDigits > 0)
+		text = digits.substr(0, integerDigits) + "." + digits.substr(integerDigits);
+	else
+		text = "0." + std::string(-integerDigits, '0') + digits;
+
+	return text + "e" + std::to_string(exponent + 1 - integerDigits);
+}
+
+}
+
+void JsonWriter::writeFloat(double value)
+{
+	// JsonParser::extractFloat does not hand numbers to strtod: it gathers the digits into an integer
+	// mantissa and scales that by a power of ten once, so writing a value at some chosen precision
+	// says nothing about the double that reading the file back returns. Reverse the parser instead:
+	// take the digits of the value from short to long, run the parser's own arithmetic over every
+	// candidate and write the first one that gives this exact double again. Numbers without an
+	// exponent are tried first, so ordinary values still read as 0.5 or 1234.5678.
+	if(!std::isfinite(value))
+	{
+		out << value;
+		return;
+	}
+
+	// digits after the decimal point that std::pow(10, fractionDigits) still scales away exactly
+	static constexpr int maxFractionDigits = 22;
+	// digits that a double carries
+	static constexpr int maxSignificantDigits = 17;
+	// above this the integer part no longer fits the si64 that the parser gathers it in
+	static constexpr double largestPlainValue = 9e18;
+
+	std::string sign = std::signbit(value) ? "-" : "";
+	double magnitude = std::abs(value);
+	std::string nearest;
+	double nearestDistance = std::numeric_limits<double>::infinity();
+
+	// Writes the candidate if the parser reads it back as this exact value. A value the parser cannot
+	// hold at all still has to be written somehow, so the candidates that read as an ordinary number
+	// also offer themselves as the fallback for that case.
+	auto writeIfExact = [&](const std::string & candidate, bool canBeFallback)
+	{
+		double readBack = readNumberBack(candidate);
+
+		if(readBack == magnitude)
+		{
+			out << sign << candidate;
+			return true;
+		}
+
+		double distance = std::abs(readBack - magnitude);
+
+		if(canBeFallback && distance < nearestDistance)
+		{
+			nearestDistance = distance;
+			nearest = candidate;
+		}
+
+		return false;
+	};
+
+	if(magnitude < largestPlainValue)
+	{
+		for(int fractionDigits = 1; fractionDigits <= maxFractionDigits; ++fractionDigits)
+		{
+			if(writeIfExact(formatFixed(magnitude, fractionDigits), true))
+				return;
+		}
+	}
+
+	std::string digits;
+	int exponent = 0;
+
+	for(int digitCount = 1; digitCount <= maxSignificantDigits; ++digitCount)
+	{
+		roundToDigits(magnitude, digitCount, digits, exponent);
+
+		if(writeIfExact(formatDigits(digits, exponent, 1), true))
+			return;
+	}
+
+	// The parser rounds a number that carries an exponent twice, once for the digits and once for the
+	// power of ten, and there are values that only survive both roundings if the decimal point sits
+	// somewhere less usual.
+	for(int digitCount = 1; digitCount <= maxSignificantDigits; ++digitCount)
+	{
+		roundToDigits(magnitude, digitCount, digits, exponent);
+
+		// the integer part has to stay inside the si64 that the parser gathers it in
+		int lastPlace = std::min(digitCount + 2, 18);
+
+		for(int integerDigits = -1; integerDigits <= lastPlace; ++integerDigits)
+		{
+			if(integerDigits == 1)
+				continue; // written the usual way above
+
+			if(writeIfExact(formatDigits(digits, exponent, integerDigits), false))
+				return;
+		}
+	}
+
+	// The parser keeps only the digits that a double holds exactly, so there are doubles that no
+	// number in a json file can produce. Write the one it comes closest to.
+	out << sign << nearest;
 }
 
 void JsonWriter::writeNode(const JsonNode & node)

--- a/lib/json/JsonWriter.h
+++ b/lib/json/JsonWriter.h
@@ -27,6 +27,7 @@ public:
 	void writeEntry(JsonMap::const_iterator entry);
 	void writeEntry(JsonVector::const_iterator entry);
 	void writeString(const std::string & string);
+	void writeFloat(double value);
 	void writeNode(const JsonNode & node);
 	JsonWriter(std::ostream & output, bool compact);
 };

--- a/test/json/JsonTests.cpp
+++ b/test/json/JsonTests.cpp
@@ -232,3 +232,18 @@ TEST(JsonTest, floatsWithMoreDigitsThanADoubleHoldsDoNotOverflow)
 	EXPECT_NEAR(json["a"].Float() / 0.12345678901234567890123456789, 1.0, 1e-15);
 	EXPECT_NEAR(json["b"].Float() / 9007199254740993.5, 1.0, 1e-15);
 }
+
+TEST(JsonTest, floatsSurviveBeingWrittenAndReadBack)
+{
+	constexpr char text[] = R"({ "a" : 0.7, "b" : -0.15, "c" : 1234.5678, "d" : 0.1234567890123 })";
+
+	JsonNode json(text, std::size(text), "Test");
+
+	std::string written = json.toCompactString();
+	JsonNode readBack(written.data(), written.size(), "Test");
+
+	EXPECT_EQ(readBack["a"].Float(), json["a"].Float());
+	EXPECT_EQ(readBack["b"].Float(), json["b"].Float());
+	EXPECT_EQ(readBack["c"].Float(), json["c"].Float());
+	EXPECT_EQ(readBack["d"].Float(), json["d"].Float());
+}


### PR DESCRIPTION
JsonWriter sent every float through an ostream at its default precision of six significant digits, so a value the parser had read as the double nearest to the number in the file was written back rounded, turning 1234.5678 into 1234.57. Reading a json file and writing it back therefore changes what it says, which affects settings, mod settings and anything the map editor saves. This formats floats with the shortest precision that reads back as the same double, so values that already fitted in six digits come out exactly as before and only the ones that were being truncated get longer. JsonTest.floatsSurviveBeingWrittenAndReadBack covers it: it fails on develop and passes with this change.
