### PR TITLE
Fix free upgrade confirmation dialogs

### DIFF
--- a/Mods/vcmi/Content/config/translations/english.json
+++ b/Mods/vcmi/Content/config/translations/english.json
@@ -495,6 +495,7 @@
 	"vcmi.creatureWindow.showBonuses.hover": "Switch to bonuses view",
 	"vcmi.creatureWindow.showSkills.help": "Display all learned skills of the commander.",
 	"vcmi.creatureWindow.showSkills.hover": "Switch to skills view",
+	"vcmi.upgrade.freeConfirm": "Do you want to upgrade these creatures?",
 	"vcmi.credits.developing": "Developing",
 	"vcmi.credits.heroes": "Heroes III",
 	"vcmi.credits.idea": "Idea",

--- a/client/windows/CCastleInterface.cpp
+++ b/client/windows/CCastleInterface.cpp
@@ -118,6 +118,17 @@ static UpgradableSlotsResult getUpgradableSlots(const CArmedInstance *obj)
 	return UpgradableSlotsResult { hasCreaturesToUpgrade, !upgradeInfos.empty(), slotInfosToDelete.empty(), costs, upgradeInfos };
 }
 
+static std::string getUpgradeAllConfirmationTextID(const UpgradableSlotsResult & upgradableSlots)
+{
+	if(!upgradableSlots.canAffordAll)
+		return "vcmi.townWindow.upgradeAll.notAllUpgradable";
+
+	if(upgradableSlots.totalCosts.empty())
+		return "vcmi.upgrade.freeConfirm";
+
+	return "core.genrltxt.207";
+}
+
 static void upgradeAllCreatures(const CArmedInstance *obj, const UpgradableSlotsResult & upgradableSlots)
 {
 	if(!upgradableSlots.canAffordAny)
@@ -129,13 +140,13 @@ static void upgradeAllCreatures(const CArmedInstance *obj, const UpgradableSlots
 	std::vector<std::shared_ptr<CComponent>> resComps;
 	for(TResources::nziterator i(upgradableSlots.totalCosts); i.valid(); i++)
 		resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, i->resType, i->resVal));
-	if(resComps.empty())
-		resComps.push_back(std::make_shared<CComponent>(ComponentType::RESOURCE, static_cast<GameResID>(GameResID::GOLD), 0)); // add at least gold, when there are no costs
-	resComps.back()->newLine = true;
+	// Free upgrades have no resource components, so only add a separator when costs are present.
+	if(!resComps.empty())
+		resComps.back()->newLine = true;
 	for(auto & upgradeInfo : upgradableSlots.upgradeInfos)
 		resComps.push_back(std::make_shared<CComponent>(ComponentType::CREATURE, upgradeInfo.second.getUpgrade(), obj->Slots().at(upgradeInfo.first)->getCount()));
 
-	std::string textID = upgradableSlots.canAffordAll ? "core.genrltxt.207" : "vcmi.townWindow.upgradeAll.notAllUpgradable";
+	const std::string textID = getUpgradeAllConfirmationTextID(upgradableSlots);
 
 	GAME->interface()->showYesNoDialog(LIBRARY->generaltexth->translate(textID), [upgradableSlots, obj](){
 		for(auto & upgradeInfo : upgradableSlots.upgradeInfos)

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -356,11 +356,6 @@ CStackWindow::BonusesSection::BonusesSection(CStackWindow * owner, int yOffset, 
 	lines->onScroll = [owner](){ owner->redraw(); };
 }
 
-static std::string getUpgradeConfirmationTextID(bool freeUpgrade)
-{
-	return freeUpgrade ? "vcmi.upgrade.freeConfirm" : "core.genrltxt.207";
-}
-
 CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 	: CWindowSection(owner, ImagePath::builtin("stackWindow/button-panel"), yOffset)
 {
@@ -407,7 +402,9 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 
 				if(GAME->interface()->cb->getResourceAmount().canAfford(totalCost))
 				{
-					const std::string textID = getUpgradeConfirmationTextID(totalCost.empty());
+					const std::string textID = totalCost.empty()
+						? "vcmi.upgrade.freeConfirm"
+						: "core.genrltxt.207";
 					GAME->interface()->showYesNoDialog(LIBRARY->generaltexth->translate(textID), onUpgrade, nullptr, resComps);
 				}
 				else

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -356,6 +356,11 @@ CStackWindow::BonusesSection::BonusesSection(CStackWindow * owner, int yOffset, 
 	lines->onScroll = [owner](){ owner->redraw(); };
 }
 
+static std::string getUpgradeConfirmationTextID(bool freeUpgrade)
+{
+	return freeUpgrade ? "vcmi.upgrade.freeConfirm" : "core.genrltxt.207";
+}
+
 CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 	: CWindowSection(owner, ImagePath::builtin("stackWindow/button-panel"), yOffset)
 {
@@ -402,7 +407,8 @@ CStackWindow::ButtonsSection::ButtonsSection(CStackWindow * owner, int yOffset)
 
 				if(GAME->interface()->cb->getResourceAmount().canAfford(totalCost))
 				{
-					GAME->interface()->showYesNoDialog(LIBRARY->generaltexth->allTexts[207], onUpgrade, nullptr, resComps);
+					const std::string textID = getUpgradeConfirmationTextID(totalCost.empty());
+					GAME->interface()->showYesNoDialog(LIBRARY->generaltexth->translate(textID), onUpgrade, nullptr, resComps);
 				}
 				else
 				{


### PR DESCRIPTION
## Summary

Use a neutral confirmation message when creature upgrades have no resource cost.

This affects both:
- single-creature upgrade dialogs,
- Upgrade All in towns.

For Upgrade All, the artificial `0 gold` resource component is also removed when all available upgrades are free.

## Context

This UI inconsistency predates configurable `SPECIAL_UPGRADE` costs and can also be reproduced with existing zero-cost upgrades, such as tier-1 upgrades at the core Hill Fort.

The configurable `SPECIAL_UPGRADE` cost feature did not introduce the issue; it only made the generic zero-cost upgrade path easier to encounter during testing.

This PR therefore fixes the shared zero-cost upgrade UI behavior rather than any `SPECIAL_UPGRADE`-specific logic.

## Behavior

Free upgrades now show:

> Do you want to upgrade these creatures?

Paid upgrades keep the existing cost confirmation text.

Insufficient-resources behavior is unchanged.

For Upgrade All:
- when all available upgrades are free, the neutral confirmation text is used and no `0 gold` component is shown,
- when free and paid upgrades are mixed, the existing cost confirmation text is used and only the actual non-zero combined cost is displayed.

## Testing

Tested locally on VCMI `develop` in RelWithDebInfo x64:

- free core Hill Fort upgrade,
- free `SPECIAL_UPGRADE`,
- paid single upgrade,
- insufficient-resources single upgrade,
- Upgrade All with all upgrades free,
- Upgrade All with mixed free and paid upgrades,
- Upgrade All for a visiting hero,
- Upgrade All for a garrison hero.

`VCMI_client` builds successfully and the tested runtime paths behave as expected.