### PR TITLE
Add a combined identificator with spellId and spell mastery

### DIFF
--- a/AI/MMAI/BAI/v13/stack.cpp
+++ b/AI/MMAI/BAI/v13/stack.cpp
@@ -478,7 +478,7 @@ void Stack::processBonuses()
 
 		if(bonus->source == BonusSource::SPELL_EFFECT)
 		{
-			switch(bonus->sid.as<SpellID>())
+			switch(bonus->sid.as<SpellWithMasteryID>().getSpellID())
 			{
 				case SpellID::AGE:
 					setflag(F2::AGE);

--- a/client/battle/BattleStacksController.cpp
+++ b/client/battle/BattleStacksController.cpp
@@ -270,16 +270,16 @@ bool BattleStacksController::stackNeedsAmountBox(const CStack * stack) const
 
 std::shared_ptr<IImage> BattleStacksController::getStackAmountBox(const CStack * stack)
 {
-	std::vector<SpellID> activeSpells = stack->activeSpells();
+	std::vector<SpellWithMasteryID> activeSpells = stack->activeSpells();
 
 	if ( activeSpells.empty())
 		return amountNormal;
 
 	int effectsPositivness = 0;
 
-	for(const auto & spellID : activeSpells)
+	for(const auto & spellWithMasteryID : activeSpells)
 	{
-		const auto * spell = spellID.toEntity(LIBRARY);
+		const auto * spell = spellWithMasteryID.getSpellID().toEntity(LIBRARY);
 		if(spell->isPositive())
 			effectsPositivness++;
 		else if(spell->isNegative())

--- a/client/battle/StackInfoBasicPanel.cpp
+++ b/client/battle/StackInfoBasicPanel.cpp
@@ -98,9 +98,10 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 		icons.push_back(std::make_shared<CAnimImage>(AnimationPath::builtin("SpellInt"), 78, 0, firstPos.x + offset.x * i, firstPos.y + offset.y * i));
 
 	int printed=0; //how many effect pics have been printed
-	std::vector<SpellID> spells = stack->activeSpells();
-	for(SpellID effect : spells)
+	std::vector<SpellWithMasteryID> spells = stack->activeSpells();
+	for(SpellWithMasteryID spellWithMastery : spells)
 	{
+		SpellID effect = spellWithMastery.getSpellID();
 		//not all effects have graphics (for eg. Acid Breath)
 		//for modded spells iconEffect is added to SpellInt.def
 		const bool hasGraphics = (effect < SpellID::THUNDERBOLT) || (effect >= SpellID::AFTER_LAST);
@@ -108,7 +109,7 @@ void StackInfoBasicPanel::initializeData(const CStack * stack)
 		if (hasGraphics)
 		{
 			//FIXME: support permanent duration
-			auto spellBonuses = stack->getBonuses(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(effect)));
+			auto spellBonuses = stack->getBonuses(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(spellWithMastery)));
 
 			if (spellBonuses->empty())
 				throw std::runtime_error("Failed to find effects for spell " + effect.toSpell()->getJsonKey());

--- a/client/windows/CCreatureWindow.cpp
+++ b/client/windows/CCreatureWindow.cpp
@@ -230,9 +230,10 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 
 	//spell effects
 	int printed=0; //how many effect pics have been printed
-	std::vector<SpellID> spells = battleStack->activeSpells();
-	for(SpellID effect : spells)
+	std::vector<SpellWithMasteryID> spells = battleStack->activeSpells();
+	for(SpellWithMasteryID spellWithMastery : spells)
 	{
+		SpellID effect = spellWithMastery.getSpellID();
 		const spells::Spell * spell = LIBRARY->spells()->getById(effect);
 
 		//not all effects have graphics (for eg. Acid Breath)
@@ -241,7 +242,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 
 		if (hasGraphics)
 		{
-			auto spellBonuses = battleStack->getBonuses(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(effect)));
+			auto spellBonuses = battleStack->getBonuses(Selector::source(BonusSource::SPELL_EFFECT, BonusSourceID(spellWithMastery)));
 			if (spellBonuses->empty())
 				throw std::runtime_error("Failed to find effects for spell " + effect.toSpell()->getJsonKey());
 
@@ -249,7 +250,7 @@ CStackWindow::ActiveSpellsSection::ActiveSpellsSection(CStackWindow * owner, int
 			std::string preferredLanguage = LIBRARY->generaltexth->getPreferredLanguage();
 
 			MetaString spellText;
-			spellText.appendTextID(spell->getDescriptionTextID(0)); // TODO: select correct mastery level?
+			spellText.appendTextID(spell->getDescriptionTextID(spellWithMastery.getMastery().getNum()));
 			spellText.appendRawString("\n");
 			spellText.appendTextID(Languages::getPluralFormTextID( preferredLanguage, duration, "vcmi.battleResultsWindow.spellDurationRemaining"));
 			spellText.replaceNumber(duration);

--- a/lib/CStack.cpp
+++ b/lib/CStack.cpp
@@ -105,23 +105,23 @@ si32 CStack::magicResistance() const
 	return static_cast<si32>(100 - castChance);
 }
 
-std::vector<SpellID> CStack::activeSpells() const
+std::vector<SpellWithMasteryID> CStack::activeSpells() const
 {
-	std::vector<SpellID> ret;
+	std::vector<SpellWithMasteryID> ret;
 
 	std::stringstream cachingStr;
 	cachingStr << "!type_" << vstd::to_underlying(BonusType::NONE) << "source_" << vstd::to_underlying(BonusSource::SPELL_EFFECT);
 	CSelector selector = Selector::sourceType()(BonusSource::SPELL_EFFECT)
 						 .And(CSelector([](const Bonus * b)->bool
 	{
-		return b->type != BonusType::NONE && b->sid.as<SpellID>().toSpell() && !b->sid.as<SpellID>().toSpell()->isAdventure();
+		return b->type != BonusType::NONE && b->sid.as<SpellWithMasteryID>().getSpellID().toSpell() && !b->sid.as<SpellWithMasteryID>().getSpellID().toSpell()->isAdventure();
 	}));
 
 	TConstBonusListPtr spellEffects = getBonuses(selector, cachingStr.str());
 	for(const auto & it : *spellEffects)
 	{
-		if(!vstd::contains(ret, it->sid.as<SpellID>()))  //do not duplicate spells with multiple effects
-			ret.push_back(it->sid.as<SpellID>());
+		if(!vstd::contains(ret, it->sid.as<SpellWithMasteryID>()))  //do not duplicate spells with multiple effects
+			ret.push_back(it->sid.as<SpellWithMasteryID>());
 	}
 
 	return ret;

--- a/lib/CStack.h
+++ b/lib/CStack.h
@@ -58,7 +58,7 @@ public:
 
 	int32_t unitLevel() const override;
 	si32 magicResistance() const override; //include aura of resistance
-	std::vector<SpellID> activeSpells() const; //returns vector of active spell IDs sorted by time of cast
+	std::vector<SpellWithMasteryID> activeSpells() const; //returns vector of active spell IDs sorted by time of cast
 	const CGHeroInstance * getMyHero() const; //if stack belongs to hero (directly or was by him summoned) returns hero, nullptr otherwise
 
 	void prepareAttacked(BattleStackAttacked & bsa, vstd::RNG & rand) const; //requires bsa.damageAmount filled

--- a/lib/battle/BattleInfo.cpp
+++ b/lib/battle/BattleInfo.cpp
@@ -785,7 +785,7 @@ void BattleInfo::updateUnit(uint32_t id, const JsonNode & data, int64_t healthDe
 		auto selector = [](const Bonus * b)
 		{
 			//Special case: persistent effects, such as DISRUPTING_RAY, survive death
-			return b->source == BonusSource::SPELL_EFFECT && !b->sid.as<SpellID>().toSpell()->isPersistent();
+			return b->source == BonusSource::SPELL_EFFECT && b->sid.as<SpellWithMasteryID>().getSpellID().toSpell()->isPersistent();
 		};
 		changedStack->removeBonusesRecursive(selector);
 	}

--- a/lib/bonuses/Bonus.cpp
+++ b/lib/bonuses/Bonus.cpp
@@ -43,7 +43,7 @@ std::string Bonus::Description(const IGameInfoCallback * cb, std::optional<si32>
 				descriptionHelper.appendName(sid.as<ArtifactID>());
 				break;
 			case BonusSource::SPELL_EFFECT:
-				descriptionHelper.appendName(sid.as<SpellID>());
+				descriptionHelper.appendName(sid.as<SpellWithMasteryID>().getSpellID());
 				break;
 			case BonusSource::CREATURE_ABILITY:
 				descriptionHelper.appendNamePlural(sid.as<CreatureID>());

--- a/lib/bonuses/BonusCustomTypes.h
+++ b/lib/bonuses/BonusCustomTypes.h
@@ -86,7 +86,7 @@ public:
 };
 
 using BonusSubtypeID = VariantIdentifier<BonusCustomSubtype, SpellID, CreatureID, PrimarySkill, TerrainId, GameResID, SpellSchool, BonusTypeID, ScriptID>;
-using BonusSourceID = VariantIdentifier<BonusCustomSource, SpellID, CreatureID, ArtifactID, CampaignScenarioID, SecondarySkill, HeroTypeID, Obj, ObjectInstanceID, BuildingTypeUniqueID, BattleField, ArtifactInstanceID>;
+using BonusSourceID = VariantIdentifier<BonusCustomSource, SpellWithMasteryID, CreatureID, ArtifactID, CampaignScenarioID, SecondarySkill, HeroTypeID, Obj, ObjectInstanceID, BuildingTypeUniqueID, BattleField, ArtifactInstanceID>;
 
 /// Kind of entity an identifier names - a creature, a spell, a terrain, ... The same vocabulary as
 /// `Identifier::entityType()`, as an enum. Bonus subtypes are given as plain identifiers

--- a/lib/constants/EntityIdentifiers.cpp
+++ b/lib/constants/EntityIdentifiers.cpp
@@ -82,6 +82,19 @@ const SpellSchool SpellSchool::WATER(3);
 
 const ScriptID ScriptID::NONE(-1);
 
+const SpellMastery SpellMastery::NONE(0);
+const SpellMastery SpellMastery::BASIC(1);
+const SpellMastery SpellMastery::ADVANCED(2);
+const SpellMastery SpellMastery::EXPERT(3);
+const SpellMastery SpellMastery::ANY(4); //used on rhs in equality operator to make it ignore mastery
+
+const std::map<int32_t, std::string> masteryIdToName = {
+	{SpellMastery::NONE.getNum() , "NONE"},
+	{SpellMastery::BASIC.getNum(), "BASIC"},
+	{SpellMastery::ADVANCED.getNum(), "ADVANCED"},
+	{SpellMastery::EXPERT.getNum(), "EXPERT"}
+};
+
 const FactionID FactionID::NONE(-2);
 const FactionID FactionID::DEFAULT(-1);
 const FactionID FactionID::RANDOM(-1);
@@ -146,6 +159,41 @@ BuildingID BuildingTypeUniqueID::getBuilding() const
 FactionID BuildingTypeUniqueID::getFaction() const
 {
 	return FactionID(getNum() / 0x10000);
+}
+
+SpellWithMasteryID::SpellWithMasteryID(SpellMastery mastery, SpellID spell):
+	Identifier(spell.getNum() * 0x1000 + mastery.getNum())
+{
+	assert(mastery.getNum() >= 0);
+	assert(mastery.getNum() < 0x1000);
+	assert(spell.getNum() >= 0);
+	assert(spell.getNum() < std::numeric_limits<int32_t>::max() - 0x1000);
+}
+
+si32 SpellWithMasteryID::decode(const std::string & identifier)
+{
+	return SpellID::decode(identifier);
+}
+
+std::string SpellWithMasteryID::encode(const si32 index)
+{
+	return SpellID::encode(SpellWithMasteryID(index).getSpellID().getNum());
+}
+
+
+SpellMastery SpellWithMasteryID::getMastery() const
+{
+	return SpellMastery(getNum() % 0x1000);
+}
+
+SpellID SpellWithMasteryID::getSpellID() const
+{
+	return SpellID(getNum() / 0x1000);
+}
+
+const CSpell * SpellWithMasteryID::toSpell() const
+{
+	return getSpellID().toSpell();
 }
 
 int32_t IdentifierBase::resolveIdentifier(const std::string & entityType, const std::string identifier)
@@ -678,6 +726,23 @@ std::string SpellSchool::entityType()
 const spells::SpellSchoolType * SpellSchool::toEntity(const Services * services) const
 {
 	return services->spellSchools()->getByIndex(getNum());
+}
+
+si32 SpellMastery::decode(const std::string & identifier)
+{
+	for (auto const & spellToName : masteryIdToName)
+	{
+		if (spellToName.second == identifier)
+			return spellToName.first;
+	}
+	return SpellMastery::ANY.getNum();
+}
+
+std::string SpellMastery::encode(const si32 index)
+{
+	if (masteryIdToName.contains(index))
+		return masteryIdToName.at(index);
+	return "ANY";
 }
 
 si32 GameResID::decode(const std::string & identifier)

--- a/lib/constants/EntityIdentifiers.h
+++ b/lib/constants/EntityIdentifiers.h
@@ -1061,6 +1061,21 @@ public:
 	const spells::SpellSchoolType * toEntity(const Services * services) const;
 };
 
+class DLL_LINKAGE SpellMastery : public StaticIdentifier<SpellMastery>
+{
+public:
+	using StaticIdentifier<SpellMastery>::StaticIdentifier;
+
+	static const SpellMastery NONE;
+	static const SpellMastery BASIC;
+	static const SpellMastery ADVANCED;
+	static const SpellMastery EXPERT;
+	static const SpellMastery ANY;
+
+	static si32 decode(const std::string & identifier);
+	static std::string encode(const si32 index);
+};
+
 /// Identifies a script of any kind - spell effect, combat event handler
 class DLL_LINKAGE ScriptID : public EntityIdentifier<ScriptID>
 {
@@ -1133,6 +1148,42 @@ public:
 
 		if (!h.saving)
 			*this = BuildingTypeUniqueID(faction, building);
+	}
+};
+
+class DLL_LINKAGE SpellWithMasteryID : public Identifier<SpellWithMasteryID>
+{
+public:
+	SpellWithMasteryID(SpellMastery mastery, SpellID spell);
+	SpellWithMasteryID(SpellID spell) : SpellWithMasteryID(SpellMastery::ANY, spell) {}
+
+	static si32 decode(const std::string & identifier);
+	static std::string encode(const si32 index);
+
+	SpellMastery getMastery() const;
+	SpellID getSpellID() const;
+	const CSpell * toSpell() const;
+
+	using Identifier<SpellWithMasteryID>::Identifier;
+
+	template <typename Handler>
+	void serialize(Handler & h)
+	{
+		SpellID spell = getSpellID();
+		SpellMastery mastery = getMastery();
+
+		h & spell;
+		h & mastery;
+
+		if (!h.saving)
+			*this = SpellWithMasteryID(mastery, spell);
+	}
+
+	bool operator==(const SpellWithMasteryID & other) const
+	{
+		if (other.getMastery() == SpellMastery::ANY)
+			return getSpellID() == other.getSpellID();
+		return getSpellID() == other.getSpellID() && getMastery() == other.getMastery();
 	}
 };
 

--- a/lib/json/JsonBonus.cpp
+++ b/lib/json/JsonBonus.cpp
@@ -267,7 +267,7 @@ static void prepareCombatScriptParameters(Bonus * b, const JsonNode & scriptNode
 	});
 }
 
-static void loadBonusSourceInstance(BonusSourceID & sourceInstance, BonusSource sourceType, const JsonNode & node)
+static void loadBonusSourceInstance(BonusSourceID & sourceInstance, BonusSource sourceType, const JsonNode & node, const JsonNode & secondaryIdNode)
 {
 	if (node.isNull())
 	{
@@ -330,9 +330,18 @@ static void loadBonusSourceInstance(BonusSourceID & sourceInstance, BonusSource 
 		}
 		case BonusSource::SPELL_EFFECT:
 		{
-			LIBRARY->identifiers()->requestIdentifier( "spell", node, [&sourceInstance](int32_t identifier)
+			SpellMastery mastery = SpellMastery::ANY;
+			if (secondaryIdNode.isString())
 			{
-				sourceInstance = SpellID(identifier);
+				mastery = SpellMastery(SpellMastery::decode(secondaryIdNode.String()));
+			}
+			else if (secondaryIdNode.isNumber())
+			{
+				mastery = SpellMastery(secondaryIdNode.Integer());
+			}
+			LIBRARY->identifiers()->requestIdentifier( "spell", node, [&sourceInstance, mastery](int32_t identifier)
+			{
+				sourceInstance = SpellWithMasteryID(mastery, identifier);
 			});
 			break;
 		}
@@ -557,6 +566,7 @@ static std::shared_ptr<const ILimiter> parseHasAnotherBonusLimiter(const JsonNod
 	const JsonNode & jsonSubtype = limiter.Struct().count("bonusSubtype") ? limiter["bonusSubtype"] : parameters[1];
 	const JsonNode & jsonSourceType = limiter.Struct().count("bonusSourceType") ? limiter["bonusSourceType"] : parameters[2]["type"];
 	const JsonNode & jsonSourceID = limiter.Struct().count("bonusSourceID") ? limiter["bonusSourceID"] : parameters[2]["id"];
+	const JsonNode & jsonSourceSecondaryId = limiter["sourceSecondaryID"];
 	const JsonNode & jsonMinValue = limiter["bonusMinValue"];
 	const JsonNode & jsonMaxValue = limiter["bonusMaxValue"];
 
@@ -587,7 +597,7 @@ static std::shared_ptr<const ILimiter> parseHasAnotherBonusLimiter(const JsonNod
 			bonusLimiter->source = sourceIt->second;
 			bonusLimiter->isSourceRelevant = true;
 			if(!jsonSourceID.isNull()) {
-				loadBonusSourceInstance(bonusLimiter->sid, bonusLimiter->source, jsonSourceID);
+				loadBonusSourceInstance(bonusLimiter->sid, bonusLimiter->source, jsonSourceID, jsonSourceSecondaryId);
 				bonusLimiter->isSourceIDRelevant = true;
 			}
 		}
@@ -838,7 +848,7 @@ bool JsonUtils::parseBonus(const JsonNode &ability, Bonus *b, const TextIdentifi
 		b->source = static_cast<BonusSource>(parseByMapN(bonusSourceMap, value, "source type "));
 
 	if (!ability["sourceID"].isNull())
-		loadBonusSourceInstance(b->sid, b->source, ability["sourceID"]);
+		loadBonusSourceInstance(b->sid, b->source, ability["sourceID"], ability["sourceSecondaryID"]);
 
 	value = &ability["targetSourceType"];
 	if (!value->isNull())
@@ -931,7 +941,7 @@ CSelector JsonUtils::parseSelector(const JsonNode & ability)
 	value = &ability["sourceID"];
 	if(!value->isNull() && src.has_value())
 	{
-		loadBonusSourceInstance(*id, *src, ability);
+		loadBonusSourceInstance(*id, *src, ability, ability["sourceSecondaryID"]);
 	}
 
 	if(src && id)

--- a/lib/spells/BattleSpellMechanics.cpp
+++ b/lib/spells/BattleSpellMechanics.cpp
@@ -626,7 +626,7 @@ bool BattleSpellMechanics::counteringSelector(const Bonus * bonus) const
 
 	for(const SpellID & id : owner->counteredSpells)
 	{
-		if(bonus->sid.as<SpellID>() == id)
+		if(bonus->sid.as<SpellWithMasteryID>().getSpellID() == id)
 			return true;
 	}
 

--- a/lib/spells/BonusCaster.cpp
+++ b/lib/spells/BonusCaster.cpp
@@ -38,7 +38,7 @@ std::string BonusCaster::getCasterNameTextID() const
 		case BonusSource::ARTIFACT:
 			return bonus->sid.as<ArtifactID>().toEntity(LIBRARY)->getNameTextID();
 		case BonusSource::SPELL_EFFECT:
-			return bonus->sid.as<SpellID>().toEntity(LIBRARY)->getNameTextID();
+			return bonus->sid.as<SpellWithMasteryID>().getSpellID().toEntity(LIBRARY)->getNameTextID();
 		case BonusSource::CREATURE_ABILITY:
 			return bonus->sid.as<CreatureID>().toEntity(LIBRARY)->getNamePluralTextID();
 		case BonusSource::SECONDARY_SKILL:

--- a/lib/spells/adventure/AdventureSpellMechanics.cpp
+++ b/lib/spells/adventure/AdventureSpellMechanics.cpp
@@ -74,7 +74,7 @@ AdventureSpellMechanics::AdventureSpellMechanics(const CSpell * s)
 		for(const auto & elem : config["bonuses"].Struct())
 		{
 			auto b = JsonUtils::parseBonus(elem.second);
-			b->sid = BonusSourceID(s->id);
+			b->sid = BonusSourceID(SpellWithMasteryID(SpellMastery(level), s->id));
 			b->source = BonusSource::SPELL_EFFECT;
 			levelOptions[level].bonuses.push_back(b);
 		}

--- a/luascript/api/library/BonusDescriptor.cpp
+++ b/luascript/api/library/BonusDescriptor.cpp
@@ -44,6 +44,7 @@ JsonNode BonusDescriptor::toJson() const
 	if(!propagator.isNull())         result["propagator"] = propagator;
 	if(!updater.isNull())            result["updater"] = updater;
 	if(!propagationUpdater.isNull()) result["propagationUpdater"] = propagationUpdater;
+	if(!sourceSecondaryID.isNull())  result["sourceSecondaryID"] = sourceSecondaryID;
 
 	return result;
 }

--- a/luascript/api/library/BonusDescriptor.h
+++ b/luascript/api/library/BonusDescriptor.h
@@ -49,6 +49,7 @@ struct BonusDescriptor final : ApiSerializable<BonusDescriptor>
 	JsonNode propagator;
 	JsonNode updater;
 	JsonNode propagationUpdater;
+	JsonNode sourceSecondaryID;
 
 	/// Builds a JsonNode matching the schema JsonUtils::parseBonus expects.
 	JsonNode toJson() const;
@@ -78,6 +79,7 @@ struct BonusDescriptor final : ApiSerializable<BonusDescriptor>
 		s("propagator",         propagator,         "Rule for propagating the bonus upwards for area effect (army-wide, player-wide, …).");
 		s("updater",            updater,            "Rules for recalculation of bonus parameters (e.g. scales with stack count).");
 		s("propagationUpdater", propagationUpdater, "Updater applied to bonuses produced by this one's propagator.");
+		s("sourceSecondaryID",  sourceSecondaryID,  "source secondary id of a bonus (for example mastery level of the spell)");
 	}
 };
 

--- a/scripts/spells/clone.lua
+++ b/scripts/spells/clone.lua
@@ -46,12 +46,13 @@ function Script:apply(mechanics, server, target)
 		server:changeUnit(battle, originalState)
 
 		server:addUnitBonus(battle, cloneUnit, {
-			duration   = ENUM.BonusDuration.nTurns,
-			type       = "NONE",
-			sourceType = ENUM.BonusSource.spellEffect,
-			val        = 0,
-			sourceID   = mechanics:getSpell():getJsonKey(),
-			turns      = mechanics:getEffectDuration()
+			duration          = ENUM.BonusDuration.nTurns,
+			type              = "NONE",
+			sourceType        = ENUM.BonusSource.spellEffect,
+			val               = 0,
+			sourceID          = mechanics:getSpell():getJsonKey(),
+			sourceSecondaryID = mechanics:getEffectLevel(),
+			turns             = mechanics:getEffectDuration()
 		}, true)
 
 		::continue::

--- a/scripts/spells/timed.lua
+++ b/scripts/spells/timed.lua
@@ -24,6 +24,7 @@ function Script:convertBonuses(mechanics)
 
 		nb.sourceType = "SPELL_EFFECT"
 		nb.sourceID = spellKey
+		nb.sourceSecondaryID = mechanics:getEffectLevel()
 
 		converted[name] = nb
 	end

--- a/server/battles/BattleActionProcessor.cpp
+++ b/server/battles/BattleActionProcessor.cpp
@@ -1358,7 +1358,10 @@ std::set<SpellID> BattleActionProcessor::getSpellsForAttackCasting(const TConstB
 		bool areCurrentLayerSpellsApplied = std::all_of(item.second.begin(), item.second.end(),
 			[&](const std::shared_ptr<Bonus> spell)
 			{
-				std::vector<SpellID> activeSpells = defender->activeSpells();
+				std::vector<SpellWithMasteryID> activeCasts = defender->activeSpells();
+				std::vector<SpellID> activeSpells;
+				for (const SpellWithMasteryID & cast : activeCasts)
+					activeSpells.push_back(cast.getSpellID());
 				return vstd::find(activeSpells, spell->subtype.as<SpellID>()) != activeSpells.end();
 			});
 

--- a/test/spells/effects/CloneTest.cpp
+++ b/test/spells/effects/CloneTest.cpp
@@ -193,7 +193,7 @@ public:
 		EXPECT_EQ(marker.duration, BonusDuration::N_TURNS);
 		EXPECT_EQ(marker.turnsRemain, effectDuration);
 		EXPECT_EQ(marker.source, BonusSource::SPELL_EFFECT);
-		EXPECT_EQ(marker.sid, BonusSourceID(SpellID(SpellID::CLONE)));
+		EXPECT_EQ(marker.sid, BonusSourceID(SpellWithMasteryID(SpellMastery::NONE, SpellID::CLONE)));
 	}
 
 	void setDefaultExpectations()
@@ -210,6 +210,7 @@ public:
 		EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return("core:clone"));
 
 		EXPECT_CALL(mechanicsMock, getEffectDuration()).WillOnce(Return(effectDuration));
+		EXPECT_CALL(mechanicsMock, getEffectLevel()).WillOnce(Return(SpellMastery::NONE.getNum()));
 		EXPECT_CALL(*battleFake, getUnitsIf(_)).Times(AtLeast(1));
 
 		EXPECT_CALL(*battleFake, nextUnitId()).WillOnce(Return(cloneId));

--- a/test/spells/effects/DispelTest.cpp
+++ b/test/spells/effects/DispelTest.cpp
@@ -22,12 +22,12 @@ class DispelFixture : public Test, public EffectFixture
 {
 public:
 	// Real game spell IDs so SpellID::encode() round-trips through LIBRARY correctly.
-	const SpellID positiveID  = SpellID::BLESS;
-	const SpellID negativeID  = SpellID::CURSE;
-	const SpellID neutralID   = SpellID::BLIND;
-	const SpellID persistentID = SpellID::HASTE;
-	const SpellID adventureID = SpellID::SLOW;
-	const SpellID currentID   = SpellID::DISPEL;
+	const SpellWithMasteryID positiveID  = SpellWithMasteryID(SpellMastery::NONE, SpellID::BLESS);
+	const SpellWithMasteryID negativeID  = SpellWithMasteryID(SpellMastery::NONE, SpellID::CURSE);
+	const SpellWithMasteryID neutralID   = SpellWithMasteryID(SpellMastery::NONE, SpellID::BLIND);
+	const SpellWithMasteryID persistentID = SpellWithMasteryID(SpellMastery::NONE, SpellID::HASTE);
+	const SpellWithMasteryID adventureID = SpellWithMasteryID(SpellMastery::NONE, SpellID::SLOW);
+	const SpellWithMasteryID currentID   = SpellWithMasteryID(SpellMastery::NONE, SpellID::DISPEL);
 
 	StrictMock<SpellMock> positiveSpell;
 	StrictMock<SpellMock> negativeSpell;
@@ -45,31 +45,31 @@ public:
 	// so the Lua filter's LIBRARY:getSpellByName() calls are satisfied.
 	void setDefaultExpectations()
 	{
-		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(positiveID.getNum())))).WillRepeatedly(Return(&positiveSpell));
+		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(positiveID.getSpellID().getNum())))).WillRepeatedly(Return(&positiveSpell));
 		EXPECT_CALL(positiveSpell, isPersistent()).WillRepeatedly(Return(false));
 		EXPECT_CALL(positiveSpell, isAdventure()).WillRepeatedly(Return(false));
 		EXPECT_CALL(positiveSpell, isPositive()).WillRepeatedly(Return(true));
 		EXPECT_CALL(positiveSpell, isNegative()).WillRepeatedly(Return(false));
 		EXPECT_CALL(positiveSpell, isNeutral()).WillRepeatedly(Return(false));
 
-		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(negativeID.getNum())))).WillRepeatedly(Return(&negativeSpell));
+		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(negativeID.getSpellID().getNum())))).WillRepeatedly(Return(&negativeSpell));
 		EXPECT_CALL(negativeSpell, isPersistent()).WillRepeatedly(Return(false));
 		EXPECT_CALL(negativeSpell, isAdventure()).WillRepeatedly(Return(false));
 		EXPECT_CALL(negativeSpell, isPositive()).WillRepeatedly(Return(false));
 		EXPECT_CALL(negativeSpell, isNegative()).WillRepeatedly(Return(true));
 		EXPECT_CALL(negativeSpell, isNeutral()).WillRepeatedly(Return(false));
 
-		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(neutralID.getNum())))).WillRepeatedly(Return(&neutralSpell));
+		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(neutralID.getSpellID().getNum())))).WillRepeatedly(Return(&neutralSpell));
 		EXPECT_CALL(neutralSpell, isPersistent()).WillRepeatedly(Return(false));
 		EXPECT_CALL(neutralSpell, isAdventure()).WillRepeatedly(Return(false));
 		EXPECT_CALL(neutralSpell, isPositive()).WillRepeatedly(Return(false));
 		EXPECT_CALL(neutralSpell, isNegative()).WillRepeatedly(Return(false));
 		EXPECT_CALL(neutralSpell, isNeutral()).WillRepeatedly(Return(true));
 
-		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(persistentID.getNum())))).WillRepeatedly(Return(&persistentSpell));
+		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(persistentID.getSpellID().getNum())))).WillRepeatedly(Return(&persistentSpell));
 		EXPECT_CALL(persistentSpell, isPersistent()).WillRepeatedly(Return(true));
 
-		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(adventureID.getNum())))).WillRepeatedly(Return(&adventureSpell));
+		EXPECT_CALL(spellServiceMock, getByName(Eq(SpellID::encode(adventureID.getSpellID().getNum())))).WillRepeatedly(Return(&adventureSpell));
 		EXPECT_CALL(adventureSpell, isPersistent()).WillRepeatedly(Return(false));
 		EXPECT_CALL(adventureSpell, isAdventure()).WillRepeatedly(Return(true));
 	}
@@ -82,7 +82,7 @@ protected:
 		// bonus list is empty, so set this up once for all tests in the fixture.
 		EXPECT_CALL(mechanicsMock, getSpell()).Times(AnyNumber()).WillRepeatedly(Return(&currentSpell));
 		EXPECT_CALL(currentSpell, getJsonKey()).Times(AnyNumber())
-			.WillRepeatedly(Return(SpellID::encode(currentID.getNum())));
+			.WillRepeatedly(Return(SpellID::encode(currentID.getSpellID().getNum())));
 	}
 };
 

--- a/test/spells/effects/TimedTest.cpp
+++ b/test/spells/effects/TimedTest.cpp
@@ -33,7 +33,7 @@ public:
 	bool cumulative = false;
 
 	// Use a real game spell so SpellID::encode() round-trips correctly.
-	const SpellID testSpellId = SpellID::CURSE;
+	const SpellWithMasteryID testSpellId = SpellWithMasteryID(SpellMastery::BASIC, SpellID::CURSE);
 	const int32_t duration = 57;
 
 	TimedApplyTest()
@@ -45,7 +45,8 @@ public:
 	{
 		unitsFake.setDefaultBonusExpectations();
 		EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
-		EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getNum())));
+		EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(SpellMastery::BASIC.getNum()));
+		EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getSpellID().getNum())));
 		EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(duration));
 		EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 	}
@@ -158,6 +159,7 @@ TEST_F(TimedTest, ApplySkipsDeadUnit)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	auto & targetUnit = unitsFake.add(BattleSide::ATTACKER);
@@ -198,6 +200,7 @@ TEST_F(TimedTest, ApplyMultipleTargets)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -232,6 +235,7 @@ TEST_F(TimedTest, ConvertBonusUsesSpellDurationWhenTurnsRemainIsZero)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(spellDuration));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -266,6 +270,7 @@ TEST_F(TimedTest, ConvertBonusKeepsExplicitTurnsRemain)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(testSpellId.getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(57)); // different from customDuration
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -298,6 +303,7 @@ TEST_F(TimedTest, ConvertBonusInvertsShieldDamageReduction)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(SpellID(SpellID::SHIELD).getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -337,6 +343,7 @@ TEST_F(TimedTest, ConvertBonusBindSetsCasterUnitId)
 	EXPECT_CALL(mechanicsMock, getSpell()).WillRepeatedly(Return(&spellStub));
 	EXPECT_CALL(spellStub, getJsonKey()).WillRepeatedly(Return(SpellID::encode(SpellID(SpellID::BIND).getNum())));
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -418,6 +425,7 @@ protected:
 		unitsFake.setDefaultBonusExpectations();
 
 		EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+		EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 		EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 		Target target;
@@ -480,6 +488,7 @@ TEST_F(TimedHeroSpecialtyTest, AddValueEnchantAddsToBonus)
 	unitsFake.setDefaultBonusExpectations();
 
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;
@@ -507,6 +516,7 @@ TEST_F(TimedHeroSpecialtyTest, FixedValueEnchantOverridesBonus)
 	unitsFake.setDefaultBonusExpectations();
 
 	EXPECT_CALL(mechanicsMock, getEffectDuration()).WillRepeatedly(Return(1));
+	EXPECT_CALL(mechanicsMock, getEffectLevel()).WillRepeatedly(Return(0));
 	EXPECT_CALL(serverMock, describeChanges()).WillRepeatedly(Return(false));
 
 	Target target;


### PR DESCRIPTION
As in the title.
It fixes #7600 and partially fixes #7680 (description still does not take into consideration other bonuses like the fire orb).

Important details:
In order to allow searching bonuses by only a spellId the spellMastery "any" has been added and equality operator of SpellWithMasteryId has been overridden. For the same reason a constructor with spellID only as the argument has been added (it allows the implicit conversion when searching by spellId).
The earlier solution was to override equality operator between SpellWithMasteryId and SpellID, unfortunately it did not work since std::variant used by the bonus class returns automatically false if variants use different template.
