### PR TITLE
Fix spurious "Stream seek failed" when loading JSON maps

### DIFF
--- a/lib/filesystem/CCompressedStream.cpp
+++ b/lib/filesystem/CCompressedStream.cpp
@@ -48,7 +48,8 @@ si64 CBufferedStream::tell()
 
 si64 CBufferedStream::skip(si64 delta)
 {
-	return seek(position + delta) - delta;
+	si64 origin = position;
+	return seek(origin + delta) - origin;
 }
 
 si64 CBufferedStream::getSize()

--- a/lib/filesystem/MinizipExtensions.cpp
+++ b/lib/filesystem/MinizipExtensions.cpp
@@ -53,7 +53,7 @@ inline long streamSeek(voidpf opaque, voidpf stream, ZPOS64_T offset, int origin
 			break;
 		case ZLIB_FILEFUNC_SEEK_END:
 		{
-			const si64 pos = actualStream->getSize() - offset;
+			const si64 pos = actualStream->getSize() + offset;
 			if(actualStream->seek(pos) != pos)
 				ret = -1;
 		}


### PR DESCRIPTION
Fixes spurious "Stream seek failed" error spam when loading VCMI JSON maps (.vmap / zip-format maps).

Two bugs:
- streamSeek() computed SEEK_END as `getSize() - offset`, but minizip passes a negative offset for backward seeks; should be `getSize() + offset`.
- CBufferedStream::skip() returned `seek(position + delta) - delta` instead of bytes actually skipped, so SEEK_CUR "failed" on buffered (zip) streams.

This triggers when reading a JSON map larger than ~64KB, or any JSON map stored inside a zip mod. Maps still load because streamSeek() always returns 0, but the wrong seek positions and error spam are fixed.