### PR TITLE
Fixes a memory leak in Actors class.

### DIFF
--- a/AI/Nullkiller2/Pathfinding/Actors.cpp
+++ b/AI/Nullkiller2/Pathfinding/Actors.cpp
@@ -299,7 +299,12 @@ ExchangeResult HeroExchangeMap::tryExchangeNoLock(const ChainActor * other)
 		auto newArmyStrength = newArmy->getArmyStrength();
 		auto oldArmyStrength = actor->creatureSet->getArmyStrength();
 
-		if(newArmyStrength <= oldArmyStrength) return result;
+		if(newArmyStrength <= oldArmyStrength)
+		{
+			delete newArmy;
+
+			return result;
+		}
 
 		auto reinforcement = newArmyStrength - oldArmyStrength;
 


### PR DESCRIPTION
Fixes a quite substantial memory leak in Actors class (over 80 mb after 2 months and a week of in-game time on a big map).

<img width="1321" height="294" alt="Screenshot From 2026-09-11 12-15-12" src="https://github.com/user-attachments/assets/55d177f5-e673-4885-a729-95c3bb80b50a" />

What happens:
Method PickBestCreatures returns a raw pointer to a object it created on a heap.
Method tryExchangeLock calls PickBestCreatures, but does not free the memory if the condition (newArmyStrength <= oldArmyStrength) is true.

PS: You can notice that the very next condition frees memory before return statement. The lack o delete statement seems to be an oversight (at no point in the logic the pointer can be copied/passed/preserved by any other way). 
PS2: I rerun the same map after changes. Before the memory usage grew almost two times counting from after the first turn to the middle of third month (from 5.x to over 10% memory taken) and after the changes it only grew to 6.3% in the same time. It seems to me even more than 80 mb.