### PR TITLE
adds qt creator internal files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ compile_commands.json
 
 # CLion
 .idea/
+.qtcreator/


### PR DESCRIPTION
Can we add this directory to gitignore?
Qtcreator creates configuration files there.

<img width="1038" height="232" alt="Screenshot From 2026-09-12 13-15-17" src="https://github.com/user-attachments/assets/58c07965-9809-4ff4-983a-bcc4a459037c" />
