### PR TITLE
Add Launcher user data change support for Windows

### DIFF
--- a/launcher/aboutProject/aboutproject_moc.cpp
+++ b/launcher/aboutProject/aboutproject_moc.cpp
@@ -11,6 +11,9 @@
 #include "aboutproject_moc.h"
 #include "ui_aboutproject_moc.h"
 
+#include <QCheckBox>
+#include <QUuid>
+
 #if defined(VCMI_ANDROID)
 #include <QAndroidJniObject>
 #endif
@@ -20,20 +23,189 @@
 
 #include "../updatedialog_moc.h"
 #include "../helper.h"
+#include "../mainwindow_moc.h"
+#include "../firstLaunch/progressoverlay.h"
+#include "../modManager/cmodlistview_moc.h"
 
 #include "../../lib/GameConstants.h"
+#include "../../lib/ScopeGuard.h"
 #include "../../lib/VCMIDirs.h"
 #include "../../lib/filesystem/CZipSaver.h"
 #include "../../lib/json/JsonUtils.h"
 #include "../../lib/filesystem/Filesystem.h"
 
-namespace
+bool AboutProjectView::isSameOrChildPath(const QString & path, const QString & parent) const
 {
-void addLastSaveToArchiveIfAvailable(CZipSaver & saver)
+	const QString cleanPath = QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+	QString cleanParent = QDir::cleanPath(QFileInfo(parent).absoluteFilePath());
+
+	if(cleanPath.compare(cleanParent, Qt::CaseInsensitive) == 0)
+		return true;
+
+	if(!cleanParent.endsWith(QDir::separator()))
+		cleanParent += QDir::separator();
+
+	return cleanPath.startsWith(cleanParent, Qt::CaseInsensitive);
+}
+
+bool AboutProjectView::containsActiveUserDirectory(const IVCMIDirs & dirs, EUserDirectory changedDirectory, const QString & path) const
+{
+	static constexpr std::array userDirectories = {
+		EUserDirectory::DATA,
+		EUserDirectory::CACHE,
+		EUserDirectory::CONFIG,
+		EUserDirectory::LOGS,
+		EUserDirectory::SAVES
+	};
+
+	for(const auto directory : userDirectories)
+	{
+		if(directory != changedDirectory && isSameOrChildPath(pathToQString(dirs.userPath(directory)), path))
+			return true;
+	}
+
+	return false;
+}
+
+bool AboutProjectView::copyDirectoryContents(const QString & source, const QString & destination, ProgressOverlay & progress, QString & error, bool overwrite)
+{
+	QDir sourceDir(source);
+	int totalFiles = 0;
+	QDirIterator counter(source, QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+	while(counter.hasNext())
+	{
+		counter.next();
+		++totalFiles;
+		if(totalFiles % 256 == 0)
+		{
+			progress.setFileName(tr("Scanning files..."));
+			qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+		}
+	}
+	progress.setRange(totalFiles);
+
+	int copiedFiles = 0;
+	QDirIterator iterator(source, QDir::NoDotAndDotDot | QDir::AllEntries, QDirIterator::Subdirectories);
+	while(iterator.hasNext())
+	{
+		const QString sourcePath = iterator.next();
+		const QString relativePath = sourceDir.relativeFilePath(sourcePath);
+		const QString destinationPath = QDir(destination).filePath(relativePath);
+		const QFileInfo sourceInfo(sourcePath);
+		if(sourceInfo.isDir())
+		{
+			if(overwrite && QFileInfo(destinationPath).isFile() && !QFile::remove(destinationPath))
+			{
+				error = tr("Failed to replace file with directory: %1").arg(destinationPath);
+				return false;
+			}
+			if(!QDir().mkpath(destinationPath))
+			{
+				error = tr("Failed to create directory: %1").arg(destinationPath);
+				return false;
+			}
+		}
+		else
+		{
+			progress.setValue(copiedFiles);
+			progress.setFileName(QDir::toNativeSeparators(relativePath));
+			qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+			if(overwrite && QFileInfo::exists(destinationPath))
+			{
+				const QFileInfo destinationInfo(destinationPath);
+				const bool removed = destinationInfo.isDir() ? QDir(destinationPath).removeRecursively() : QFile::remove(destinationPath);
+				if(!removed)
+				{
+					error = tr("Failed to overwrite: %1").arg(destinationPath);
+					return false;
+				}
+			}
+			if(!QDir().mkpath(QFileInfo(destinationPath).absolutePath()) || !QFile::copy(sourcePath, destinationPath))
+			{
+				error = tr("Failed to copy file: %1").arg(sourcePath);
+				return false;
+			}
+			++copiedFiles;
+		}
+	}
+	progress.setValue(totalFiles);
+	progress.setFileName(QString());
+	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+	return true;
+}
+
+std::optional<AboutProjectView::EExistingTargetAction> AboutProjectView::askExistingTargetAction(const QString & target)
+{
+	QMessageBox dialog(QMessageBox::Question, tr("Directory is not empty"), tr("The target directory already contains files:\n%1\n\nHow should they be handled?").arg(QDir::toNativeSeparators(target)), QMessageBox::NoButton, this);
+	dialog.setInformativeText(tr("Merge keeps files that exist only in the target and overwrites conflicts.\nBack up and replace moves the current target to a _backup directory.\nClean replacement removes the current target after the new copy is ready."));
+
+	auto * mergeButton = dialog.addButton(tr("Merge and overwrite"), QMessageBox::AcceptRole);
+	auto * backupButton = dialog.addButton(tr("Back up and replace"), QMessageBox::ActionRole);
+	auto * replaceButton = dialog.addButton(tr("Clean replacement"), QMessageBox::DestructiveRole);
+
+	dialog.addButton(QMessageBox::Cancel);
+	dialog.setDefaultButton(backupButton);
+	dialog.exec();
+
+	if(dialog.clickedButton() == mergeButton)
+		return EExistingTargetAction::MERGE;
+
+	if(dialog.clickedButton() == backupButton)
+		return EExistingTargetAction::BACK_UP;
+
+	if(dialog.clickedButton() == replaceButton)
+		return EExistingTargetAction::REPLACE;
+
+	return std::nullopt;
+}
+
+QString AboutProjectView::availableBackupPath(const QString & target) const
+{
+	const QString basePath = target + QStringLiteral("_backup");
+	if(!QFileInfo::exists(basePath))
+		return basePath;
+
+	for(int index = 2; ; ++index)
+	{
+		const QString candidate = basePath + QStringLiteral("_%1").arg(index);
+		if(!QFileInfo::exists(candidate))
+			return candidate;
+	}
+}
+
+bool AboutProjectView::installStagedDirectory(const QString & staging, const QString & target, EExistingTargetAction action, QString & backupPath, QString & error)
+{
+	const QFileInfo targetInfo(target);
+	const QString temporaryPath = targetInfo.dir().filePath(QStringLiteral(".%1-vcmi-old-%2").arg(targetInfo.fileName(), QUuid::createUuid().toString(QUuid::Id128)));
+	const QString displacedPath = action == EExistingTargetAction::BACK_UP ? availableBackupPath(target) : temporaryPath;
+
+	if(!QDir().rename(target, displacedPath))
+	{
+		error = tr("Failed to move the existing target directory: %1").arg(target);
+		return false;
+	}
+
+	if(!QDir().rename(staging, target))
+	{
+		QDir().rename(displacedPath, target);
+		error = tr("Failed to place copied files in the selected directory.");
+		return false;
+	}
+
+	if(action == EExistingTargetAction::BACK_UP)
+		backupPath = displacedPath;
+	else if(!QDir(displacedPath).removeRecursively())
+	{
+		error = tr("The new data was installed, but the replaced directory could not be removed: %1").arg(displacedPath);
+	}
+	return true;
+}
+
+static void addLastSaveToArchiveIfAvailable(CZipSaver & saver)
 {
 	const auto json = JsonUtils::assembleFromFiles("config/settings.json");
 	const auto lastSavePath = json["general"]["lastSave"].String();
-	if (lastSavePath.empty())
+	if(lastSavePath.empty())
 		return;
 	const auto rsave = ResourcePath(lastSavePath, EResType::SAVEGAME);
 	const auto * rhandler = CResourceHandler::get();
@@ -46,7 +218,6 @@ void addLastSaveToArchiveIfAvailable(CZipSaver & saver)
 	const auto & [data, length] = rhandler->load(rsave)->readAll();
 	auto stream = saver.addFile(name + ".vsgm1");
 	stream->write(data.get(), length);
-}
 }
 
 void AboutProjectView::hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch)
@@ -69,12 +240,18 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 {
 	ui->setupUi(this);
 
-	ui->lineEditUserDataDir->setText(pathToQString(VCMIDirs::get().userDataPath()));
-	ui->lineEditGameDir->setText(pathToQString(VCMIDirs::get().binaryPath()));
-	ui->lineEditTempDir->setText(pathToQString(VCMIDirs::get().userLogsPath()));
-	ui->lineEditConfigDir->setText(pathToQString(VCMIDirs::get().userConfigPath()));
+	refreshDirectoryPaths();
+	ui->lineEditGameDir->setText(pathToQString(boost::filesystem::absolute(VCMIDirs::get().binaryPath())));
 	ui->lineEditBuildVersion->setText(QString(GameConstants::VCMI_VERSION));
 	ui->lineEditOperatingSystem->setText(QSysInfo::prettyProductName());
+
+#ifndef VCMI_WINDOWS
+	ui->changeUserDataDir->hide();
+	ui->changeTempDir->hide();
+	ui->changeCacheDir->hide();
+	ui->changeConfigDir->hide();
+	ui->changeSaveDir->hide();
+#endif
 
 #ifdef VCMI_MOBILE
 	// On mobile platforms these directories are generally not accessible from phone itself, only via USB connection from PC
@@ -82,15 +259,27 @@ AboutProjectView::AboutProjectView(QWidget * parent)
 	hideAndStretchWidget(ui->gridLayout, ui->openGameDataDir, ui->lineEditGameDir);
 #ifdef VCMI_ANDROID
 	hideAndStretchWidget(ui->gridLayout, ui->openUserDataDir, ui->lineEditUserDataDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openCacheDir, ui->lineEditCacheDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openTempDir, ui->lineEditTempDir);
 	hideAndStretchWidget(ui->gridLayout, ui->openConfigDir, ui->lineEditConfigDir);
+	hideAndStretchWidget(ui->gridLayout, ui->openSaveDir, ui->lineEditSaveDir);
 #endif
 #endif
 }
 
 AboutProjectView::~AboutProjectView() = default;
 
-void AboutProjectView::changeEvent(QEvent *event)
+void AboutProjectView::refreshDirectoryPaths()
+{
+	const auto & dirs = VCMIDirs::get();
+	ui->lineEditUserDataDir->setText(pathToQString(dirs.userDataPath()));
+	ui->lineEditCacheDir->setText(pathToQString(dirs.userCachePath()));
+	ui->lineEditConfigDir->setText(pathToQString(dirs.userConfigPath()));
+	ui->lineEditTempDir->setText(pathToQString(dirs.userLogsPath()));
+	ui->lineEditSaveDir->setText(pathToQString(dirs.userSavePath()));
+}
+
+void AboutProjectView::changeEvent(QEvent * event)
 {
 	if(event->type() == QEvent::LanguageChange)
 		ui->retranslateUi(this);
@@ -121,6 +310,205 @@ void AboutProjectView::on_openTempDir_clicked()
 void AboutProjectView::on_openConfigDir_clicked()
 {
 	Helper::revealDirectoryInFileBrowser(ui->lineEditConfigDir->text());
+}
+
+void AboutProjectView::changeDirectory(EUserDirectory directory, const QString & title)
+{
+#ifdef VCMI_WINDOWS
+	auto * mainWindow = qobject_cast<MainWindow *>(window());
+	auto & dirs = VCMIDirs::get();
+	const QString source = pathToQString(dirs.userPath(directory));
+	const QString selected = QFileDialog::getExistingDirectory(this, title, source);
+
+	if(selected.isEmpty())
+		return;
+
+	if(isSameOrChildPath(selected, source) && isSameOrChildPath(source, selected))
+		return;
+
+	if(isSameOrChildPath(selected, source))
+	{
+		QMessageBox::warning(this, tr("Invalid directory"), tr("The new directory cannot be inside the current directory."));
+		return;
+	}
+
+	if(isSameOrChildPath(source, selected))
+	{
+		QMessageBox::warning(this, tr("Invalid directory"), tr("The new directory cannot contain the current directory."));
+		return;
+	}
+
+	const QString oldLogPath = pathToQString(dirs.userLogsPath());
+	bool moveExistingData = false;
+	bool downloadsPaused = false;
+	QString targetBackupPath;
+
+	auto cancelPausedDownloads = vstd::makeScopeGuard([&]()
+	{
+		if(downloadsPaused && mainWindow)
+			mainWindow->getModView()->cancelDownloads();
+	});
+
+	auto pauseDownloads = [&]()
+	{
+		if(!downloadsPaused && mainWindow)
+			downloadsPaused = mainWindow->getModView()->pauseDownloads();
+	};
+
+	QDir sourceDir(source);
+	const bool sourceHasData = sourceDir.exists() && !sourceDir.entryList(QDir::NoDotAndDotDot | QDir::AllEntries).isEmpty();
+
+	if(sourceHasData)
+	{
+		QMessageBox copyDialog(QMessageBox::Question, tr("Copy existing data?"), tr("Do you want to copy the existing files?\n\nFrom:\n%1\n\nTo:\n%2").arg(QDir::toNativeSeparators(source), QDir::toNativeSeparators(selected)), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, this);
+		copyDialog.setDefaultButton(QMessageBox::Yes);
+
+		auto * moveCheckBox = new QCheckBox(tr("Move existing data (remove the original files after a successful reload)"));
+		copyDialog.setCheckBox(moveCheckBox);
+
+		const auto answer = static_cast<QMessageBox::StandardButton>(copyDialog.exec());
+
+		if(answer == QMessageBox::Cancel)
+			return;
+
+		if(answer == QMessageBox::Yes)
+		{
+			moveExistingData = moveCheckBox->isChecked();
+			QDir destinationDir(selected);
+			EExistingTargetAction targetAction = EExistingTargetAction::REPLACE;
+
+			if(!destinationDir.entryList(QDir::NoDotAndDotDot | QDir::AllEntries).isEmpty())
+			{
+				const auto selectedAction = askExistingTargetAction(selected);
+				if(!selectedAction)
+					return;
+
+				targetAction = *selectedAction;
+			}
+
+			pauseDownloads();
+
+			QTemporaryDir stagingDirectory(QFileInfo(selected).dir().filePath(QStringLiteral(".vcmi-transfer-XXXXXX")));
+			if(!stagingDirectory.isValid())
+			{
+				QMessageBox::critical(this, tr("Error"), tr("Failed to create a temporary transfer directory."));
+				return;
+			}
+
+			auto progressOverlay = std::make_unique<ProgressOverlay>(window(), 0);
+			progressOverlay->setTitle(tr("Copying directory..."));
+			progressOverlay->setIndeterminate(true);
+			progressOverlay->show();
+			progressOverlay->raise();
+			qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+
+			QString error;
+			if(targetAction == EExistingTargetAction::MERGE && !copyDirectoryContents(selected, stagingDirectory.path(), *progressOverlay, error))
+			{
+				progressOverlay.reset();
+				QMessageBox::critical(this, tr("Copy failed"), error);
+				return;
+			}
+
+			if(!copyDirectoryContents(source, stagingDirectory.path(), *progressOverlay, error, targetAction == EExistingTargetAction::MERGE))
+			{
+				progressOverlay.reset();
+				QMessageBox::critical(this, tr("Copy failed"), error);
+				return;
+			}
+
+			progressOverlay.reset();
+
+			const QString stagingPath = stagingDirectory.path();
+			if(!installStagedDirectory(stagingPath, selected, targetAction, targetBackupPath, error))
+			{
+				QMessageBox::critical(this, tr("Copy failed"), error);
+				return;
+			}
+
+			stagingDirectory.setAutoRemove(false);
+			if(!error.isEmpty())
+				QMessageBox::warning(this, tr("Cleanup failed"), error);
+		}
+	}
+	pauseDownloads();
+
+	if(!dirs.setUserPath(directory, qstringToPath(selected)))
+	{
+		QMessageBox::critical(this, tr("Error"), tr("Failed to save directory settings to config/dirs.json."));
+		return;
+	}
+
+	refreshDirectoryPaths();
+	const QString newLogPath = pathToQString(dirs.userLogsPath());
+
+	if(oldLogPath != newLogPath)
+		emit logDirectoryChanged(newLogPath);
+
+	if(!mainWindow || !mainWindow->reloadDirectories())
+		return;
+
+	if(downloadsPaused)
+	{
+		mainWindow->getModView()->resumeDownloads();
+		downloadsPaused = false;
+	}
+
+	if(moveExistingData)
+	{
+		if(containsActiveUserDirectory(dirs, directory, source))
+		{
+			QMessageBox::warning(this, tr("Original files kept"), tr("The original directory still contains another active VCMI directory and cannot be removed safely."));
+			return;
+		}
+		if(!QDir(source).removeRecursively())
+		{
+			QMessageBox::warning(this, tr("Original files kept"), tr("The data was copied and reloaded, but the original directory could not be removed."));
+			return;
+		}
+	}
+	const QString successMessage = targetBackupPath.isEmpty() ? tr("The launcher has reloaded files from the new directory.") : tr("The launcher has reloaded files from the new directory.\n\nThe previous target was saved to:\n%1").arg(QDir::toNativeSeparators(targetBackupPath));
+	QMessageBox::information(this, tr("Directory changed"), successMessage);
+#else
+	// TODO: Every Non-Windows OS is unsupported
+	Q_UNUSED(directory);
+	Q_UNUSED(title);
+#endif
+}
+
+void AboutProjectView::on_changeUserDataDir_clicked()
+{
+	changeDirectory(EUserDirectory::DATA, tr("Select user data directory"));
+}
+
+void AboutProjectView::on_changeTempDir_clicked()
+{
+	changeDirectory(EUserDirectory::LOGS, tr("Select log files directory"));
+}
+
+void AboutProjectView::on_openCacheDir_clicked()
+{
+	Helper::revealDirectoryInFileBrowser(ui->lineEditCacheDir->text());
+}
+
+void AboutProjectView::on_changeCacheDir_clicked()
+{
+	changeDirectory(EUserDirectory::CACHE, tr("Select cache directory"));
+}
+
+void AboutProjectView::on_changeConfigDir_clicked()
+{
+	changeDirectory(EUserDirectory::CONFIG, tr("Select configuration files directory"));
+}
+
+void AboutProjectView::on_openSaveDir_clicked()
+{
+	Helper::revealDirectoryInFileBrowser(ui->lineEditSaveDir->text());
+}
+
+void AboutProjectView::on_changeSaveDir_clicked()
+{
+	changeDirectory(EUserDirectory::SAVES, tr("Select saved games directory"));
 }
 
 void AboutProjectView::on_pushButtonDiscord_clicked()

--- a/launcher/aboutProject/aboutproject_moc.h
+++ b/launcher/aboutProject/aboutproject_moc.h
@@ -15,20 +15,41 @@ namespace Ui
 class AboutProjectView;
 }
 
-class CModListView;
+class ProgressOverlay;
+class IVCMIDirs;
+enum class EUserDirectory;
 
 class AboutProjectView : public QWidget
 {
 	Q_OBJECT
 
-	void changeEvent(QEvent *event) override;
+	enum class EExistingTargetAction
+	{
+		MERGE,
+		BACK_UP,
+		REPLACE
+	};
+
+	void changeEvent(QEvent * event) override;
 
 	/// Hides a widget and expands second widgets to take place of first widget in layout
 	void hideAndStretchWidget(QGridLayout * layout, QWidget * toHide, QWidget * toStretch);
 
+	void refreshDirectoryPaths();
+	void changeDirectory(EUserDirectory directory, const QString & title);
+	bool isSameOrChildPath(const QString & path, const QString & parent) const;
+	bool containsActiveUserDirectory(const IVCMIDirs & dirs, EUserDirectory changedDirectory, const QString & path) const;
+	bool copyDirectoryContents(const QString & source,	const QString & destination, ProgressOverlay & progress, QString & error, bool overwrite = false);
+	std::optional<EExistingTargetAction> askExistingTargetAction(const QString & target);
+	QString availableBackupPath(const QString & target) const;
+	bool installStagedDirectory(const QString & staging, const QString & target, EExistingTargetAction action, QString & backupPath, QString & error);
+
 public:
 	explicit AboutProjectView(QWidget * parent = nullptr);
 	~AboutProjectView() override;
+
+signals:
+	void logDirectoryChanged(const QString & path);
 
 private slots:
 	void on_updatesButton_clicked();
@@ -52,6 +73,20 @@ private slots:
 	void on_pushButtonExportSaves_clicked();
 
 	void on_openConfigDir_clicked();
+
+	void on_changeUserDataDir_clicked();
+
+	void on_changeTempDir_clicked();
+
+	void on_openCacheDir_clicked();
+
+	void on_changeCacheDir_clicked();
+
+	void on_changeConfigDir_clicked();
+
+	void on_openSaveDir_clicked();
+
+	void on_changeSaveDir_clicked();
 
 private:
 	std::unique_ptr<Ui::AboutProjectView> ui;

--- a/launcher/aboutProject/aboutproject_moc.ui
+++ b/launcher/aboutProject/aboutproject_moc.ui
@@ -71,7 +71,7 @@
     </spacer>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout" columnstretch="2,4,1">
+    <layout class="QGridLayout" name="gridLayout" columnstretch="2,4,1,1">
      <item row="2" column="1">
       <widget class="QLineEdit" name="lineEditOperatingSystem">
        <property name="text">
@@ -96,6 +96,13 @@
        </property>
       </widget>
      </item>
+     <item row="5" column="3">
+      <widget class="QPushButton" name="changeUserDataDir">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="labelDataDirs">
        <property name="font">
@@ -108,7 +115,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="labelTempDir">
        <property name="text">
         <string>Log files directory</string>
@@ -122,7 +129,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="8" column="1">
       <widget class="QLineEdit" name="lineEditTempDir">
        <property name="enabled">
         <bool>true</bool>
@@ -143,6 +150,9 @@
        <property name="text">
         <string notr="true">/usr/share/vcmi</string>
        </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">
@@ -155,17 +165,24 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="2">
+     <item row="8" column="2">
       <widget class="QPushButton" name="openTempDir">
        <property name="text">
         <string>Open</string>
        </property>
       </widget>
      </item>
+     <item row="8" column="3">
+      <widget class="QPushButton" name="changeTempDir">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="labelGameDir">
        <property name="text">
-        <string>Game data directory</string>
+        <string>Installation directory</string>
        </property>
       </widget>
      </item>
@@ -245,6 +262,69 @@
       <widget class="QPushButton" name="openConfigDir">
        <property name="text">
         <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="3">
+      <widget class="QPushButton" name="changeConfigDir">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelCacheDir">
+       <property name="text">
+        <string>Cache directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="lineEditCacheDir">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QPushButton" name="openCacheDir">
+       <property name="text">
+        <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QPushButton" name="changeCacheDir">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelSaveDir">
+       <property name="text">
+        <string>Saved games directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLineEdit" name="lineEditSaveDir">
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="2">
+      <widget class="QPushButton" name="openSaveDir">
+       <property name="text">
+        <string>Open</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="3">
+      <widget class="QPushButton" name="changeSaveDir">
+       <property name="text">
+        <string>Change</string>
        </property>
       </widget>
      </item>

--- a/launcher/mainwindow_moc.cpp
+++ b/launcher/mainwindow_moc.cpp
@@ -24,6 +24,8 @@
 #include "updatedialog_moc.h"
 #include "main.h"
 #include "helper.h"
+#include "firstLaunch/progressoverlay.h"
+
 #ifndef VCMI_MOBILE
 #include "gamepadHandler.h"
 #endif
@@ -36,12 +38,12 @@ void MainWindow::load()
 
 #ifndef VCMI_MOBILE
 	console = std::make_unique<CConsoleHandler>();
-	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console.get());
+	logConfigurator = std::make_unique<CBasicLogConfigurator>(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", console.get());
 #else
-	CBasicLogConfigurator logConfigurator(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", nullptr);
+	logConfigurator = std::make_unique<CBasicLogConfigurator>(VCMIDirs::get().userLogsPath() / "VCMI_Launcher_log.txt", nullptr);
 #endif
 
-	logConfigurator.configureDefault();
+	logConfigurator->configureDefault();
 
 	try
 	{
@@ -91,6 +93,7 @@ MainWindow::MainWindow(QWidget * parent)
 	updateTranslation(); // load translation
 
 	ui->setupUi(this);
+	connect(ui->aboutView, &AboutProjectView::logDirectoryChanged, this, &MainWindow::reconfigureLogDirectory);
 
 #ifndef VCMI_MOBILE
 	connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *)
@@ -147,6 +150,66 @@ MainWindow::MainWindow(QWidget * parent)
 
 	if(settings["launcher"]["updateOnStartup"].Bool())
 		UpdateDialog::showUpdateDialog(false);
+}
+
+void MainWindow::reconfigureLogDirectory(const QString & path)
+{
+	logConfigurator->deconfigure();
+
+#ifndef VCMI_MOBILE
+	logConfigurator = std::make_unique<CBasicLogConfigurator>(qstringToPath(path) / "VCMI_Launcher_log.txt", console.get(), true);
+#else
+	logConfigurator = std::make_unique<CBasicLogConfigurator>(qstringToPath(path) / "VCMI_Launcher_log.txt", nullptr, true);
+#endif
+
+	logConfigurator->configure();
+	logGlobal->info("Launcher log directory changed to %s", path.toStdString());
+}
+
+bool MainWindow::reloadDirectories()
+{
+	auto progressOverlay = std::make_unique<ProgressOverlay>(this, 0);
+	progressOverlay->setTitle(tr("Reloading launcher data..."));
+	progressOverlay->setIndeterminate(true);
+	progressOverlay->show();
+	progressOverlay->raise();
+
+	auto updateProgress = [&progressOverlay](const QString & message)
+	{
+		progressOverlay->setFileName(message);
+		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+	};
+
+	try
+	{
+		updateProgress(tr("Closing the current filesystem..."));
+		CResourceHandler::destroy();
+
+		updateProgress(tr("Initializing directories..."));
+		CResourceHandler::initialize();
+
+		updateProgress(tr("Loading game data..."));
+		CResourceHandler::load("config/filesystem.json");
+
+		updateProgress(tr("Reloading settings and mods..."));
+		Helper::reLoadSettings();
+
+		updateProgress(tr("Refreshing the launcher..."));
+		ui->startGameView->refreshState();
+		const bool h3DataFound = CResourceHandler::get()->existsResource(ResourcePath("DATA/GENRLTXT.TXT"));
+		setGamepadStartAllowed(h3DataFound && settings["launcher"]["setupCompleted"].Bool());
+
+		logGlobal->info("Reloaded launcher filesystem after directory change");
+
+		progressOverlay.reset();
+		return true;
+	}
+	catch(const std::exception & e)
+	{
+		progressOverlay.reset();
+		QMessageBox::critical(this, tr("Failed to reload directories"), QString::fromUtf8(e.what()));
+		return false;
+	}
 }
 
 void MainWindow::setGamepadStartAllowed(bool allowed)

--- a/launcher/mainwindow_moc.h
+++ b/launcher/mainwindow_moc.h
@@ -13,6 +13,7 @@
 #include <QTranslator>
 
 class CConsoleHandler;
+class CBasicLogConfigurator;
 
 namespace Ui
 {
@@ -45,6 +46,7 @@ class MainWindow : public QMainWindow
 #ifndef VCMI_MOBILE
 	std::unique_ptr<CConsoleHandler> console;
 #endif
+	std::unique_ptr<CBasicLogConfigurator> logConfigurator;
 
 	bool gamepadStartAllowed = false;
 
@@ -82,6 +84,7 @@ public:
 	void switchToModsTab();
 	void switchToStartTab();
 	void moveToScreen(int screenIndex);
+	bool reloadDirectories();
 
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dropEvent(QDropEvent *event) override;
@@ -99,4 +102,5 @@ private slots:
 	void on_modslistButton_clicked();
 	void on_settingsButton_clicked();
 	void on_aboutButton_clicked();
+	void reconfigureLogDirectory(const QString & path);
 };

--- a/launcher/modManager/cdownloadmanager_moc.cpp
+++ b/launcher/modManager/cdownloadmanager_moc.cpp
@@ -28,26 +28,31 @@ void CDownloadManager::downloadFile(const QUrl & url, const QString & file, qint
 {
 	FileEntry entry;
 	entry.url = url;
-	entry.file.reset(new QFile(QString{QLatin1String{"%1/%2"}}.arg(CLauncherDirs::downloadsPath(), file)));
 	entry.bytesReceived = 0;
 	entry.totalSize = bytesTotal;
 	entry.filename = file;
 	entry.reply = nullptr;
 	entry.status = FileEntry::QUEUED;
 
-	if(entry.file->open(QIODevice::WriteOnly | QIODevice::Truncate))
-	{
-		// file prepared, download will start when this entry reaches queue head
-	}
-	else
-	{
-		entry.status = FileEntry::FAILED;
-		encounteredErrors += entry.file->errorString();
-	}
+	if(!downloadsPaused)
+		openDownloadFile(entry);
 
 	// even if failed - add it into list to report it in finished() call
 	currentDownloads.push_back(entry);
 	startNextDownload();
+}
+
+bool CDownloadManager::openDownloadFile(FileEntry & entry)
+{
+	QDir().mkpath(CLauncherDirs::downloadsPath());
+	entry.file.reset(new QFile(QString{QLatin1String{"%1/%2"}}.arg(CLauncherDirs::downloadsPath(), entry.filename)));
+
+	if(entry.file->open(QIODevice::WriteOnly | QIODevice::Truncate))
+		return true;
+
+	entry.status = FileEntry::FAILED;
+	encounteredErrors += entry.file->errorString();
+	return false;
 }
 
 CDownloadManager::FileEntry & CDownloadManager::getEntry(QNetworkReply * reply)
@@ -63,6 +68,12 @@ CDownloadManager::FileEntry & CDownloadManager::getEntry(QNetworkReply * reply)
 
 void CDownloadManager::downloadFinished(QNetworkReply * reply)
 {
+	if(ignoredReplies.remove(reply))
+	{
+		reply->deleteLater();
+		return;
+	}
+
 	FileEntry & file = getEntry(reply);
 
 	QVariant possibleRedirectUrl = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
@@ -159,6 +170,50 @@ bool CDownloadManager::downloadInProgress(const QUrl & url) const
 	return false;
 }
 
+void CDownloadManager::pauseDownloads()
+{
+	if(downloadsPaused)
+		return;
+
+	downloadsPaused = true;
+	for(auto & entry : currentDownloads)
+	{
+		if(entry.status != FileEntry::QUEUED && entry.status != FileEntry::IN_PROGRESS)
+			continue;
+
+		if(entry.reply)
+		{
+			disconnect(entry.reply, nullptr, this, nullptr);
+			ignoredReplies.insert(entry.reply);
+			entry.reply->abort();
+			entry.reply->deleteLater();
+			entry.reply = nullptr;
+		}
+		if(entry.file)
+		{
+			entry.file->close();
+			entry.file->remove();
+			entry.file.reset();
+		}
+		entry.status = FileEntry::QUEUED;
+		entry.bytesReceived = 0;
+	}
+}
+
+void CDownloadManager::resumeDownloads()
+{
+	if(!downloadsPaused)
+		return;
+
+	downloadsPaused = false;
+	for(auto & entry : currentDownloads)
+	{
+		if(entry.status == FileEntry::QUEUED)
+			openDownloadFile(entry);
+	}
+	startNextDownload();
+}
+
 void CDownloadManager::startDownload(FileEntry & entry)
 {
 	QNetworkRequest request(entry.url);
@@ -171,6 +226,9 @@ void CDownloadManager::startDownload(FileEntry & entry)
 
 void CDownloadManager::startNextDownload()
 {
+	if(downloadsPaused)
+		return;
+
 	if(hasDownloadInProgress())
 		return;
 

--- a/launcher/modManager/cdownloadmanager_moc.h
+++ b/launcher/modManager/cdownloadmanager_moc.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <QSet>
 #include <QSharedPointer>
 #include <QtNetwork/QNetworkReply>
 
@@ -38,12 +39,15 @@ class CDownloadManager : public QObject
 	};
 
 	QStringList encounteredErrors;
+	QSet<QNetworkReply *> ignoredReplies;
 
 	QNetworkAccessManager manager;
 
 	QList<FileEntry> currentDownloads;
+	bool downloadsPaused = false;
 
 	FileEntry & getEntry(QNetworkReply * reply);
+	bool openDownloadFile(FileEntry & entry);
 	void startDownload(FileEntry & entry);
 	void startNextDownload();
 	bool hasDownloadInProgress() const;
@@ -54,6 +58,8 @@ public:
 	// returns true if download with such URL is in progress/queued
 	// FIXME: not sure what's right place for "mod download in progress" check
 	bool downloadInProgress(const QUrl & url) const;
+	void pauseDownloads();
+	void resumeDownloads();
 
 	// returns network reply so caller can connect to required signals
 	void downloadFile(const QUrl & url, const QString & file, qint64 bytesTotal = 0);

--- a/launcher/modManager/cmodlistview_moc.cpp
+++ b/launcher/modManager/cmodlistview_moc.cpp
@@ -868,6 +868,33 @@ void CModListView::downloadFile(QString file, QUrl url, QString description, qin
 	dlManager->downloadFile(url, file, sizeBytes);
 }
 
+bool CModListView::pauseDownloads()
+{
+	if(!dlManager)
+		return false;
+
+	dlManager->pauseDownloads();
+	return true;
+}
+
+void CModListView::resumeDownloads()
+{
+	if(dlManager)
+		dlManager->resumeDownloads();
+}
+
+void CModListView::cancelDownloads()
+{
+	delete dlManager;
+	dlManager = nullptr;
+	enqueuedModDownloads.clear();
+	enqueuedDownloadFiles.clear();
+	enqueuedDownloadDescriptions.clear();
+	activeDownloadFile.clear();
+	Helper::keepScreenOn(false);
+	hideProgressBar();
+}
+
 void CModListView::downloadProgress(QString currentFile, qint64 current, qint64 max)
 {
 	Q_UNUSED(currentFile);
@@ -1639,14 +1666,7 @@ void CModListView::on_refreshButton_clicked()
 
 void CModListView::on_abortButton_clicked()
 {
-	delete dlManager;
-	dlManager = nullptr;
-	enqueuedModDownloads.clear();
-	enqueuedDownloadFiles.clear();
-	enqueuedDownloadDescriptions.clear();
-	activeDownloadFile.clear();
-	Helper::keepScreenOn(false);
-	hideProgressBar();
+	cancelDownloads();
 }
 
 void CModListView::modelReset()

--- a/launcher/modManager/cmodlistview_moc.h
+++ b/launcher/modManager/cmodlistview_moc.h
@@ -78,6 +78,9 @@ public:
 
 	void loadScreenshots();
 	void loadRepositories();
+	bool pauseDownloads();
+	void resumeDownloads();
+	void cancelDownloads();
 
 	void reload(const QString& modToSelect = QString());
 

--- a/launcher/modManager/modstatemodel.cpp
+++ b/launcher/modManager/modstatemodel.cpp
@@ -13,6 +13,10 @@
 #include "../../lib/filesystem/Filesystem.h"
 #include "../../lib/modding/ModManager.h"
 
+#include <QEventLoop>
+#include <QFutureWatcher>
+#include <QtConcurrent/QtConcurrentRun>
+
 ModStateModel::ModStateModel()
 	: repositoryData(std::make_unique<JsonNode>())
 	, modManager(std::make_unique<ModManager>())
@@ -29,8 +33,35 @@ void ModStateModel::setRepositoryData(const JsonNode & repositoriesList)
 
 void ModStateModel::reloadLocalState()
 {
-	CResourceHandler::get("initial")->updateFilteredFiles([](const std::string &){ return true; });
-	modManager = std::make_unique<ModManager>(*repositoryData);
+	const JsonNode repositories = *repositoryData;
+
+	std::unique_ptr<ModManager> reloadedManager;
+	std::exception_ptr reloadException;
+
+	QFutureWatcher<void> watcher;
+	QEventLoop eventLoop;
+	QObject::connect(&watcher, &QFutureWatcher<void>::finished, &eventLoop, &QEventLoop::quit);
+
+	watcher.setFuture(QtConcurrent::run([&]()
+	{
+		try
+		{
+			CResourceHandler::get("initial")->updateFilteredFiles([](const std::string &){ return true; });
+			reloadedManager = std::make_unique<ModManager>(repositories);
+		}
+		catch(...)
+		{
+			reloadException = std::current_exception();
+		}
+	}));
+
+	eventLoop.exec(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers);
+	watcher.waitForFinished();
+
+	if(reloadException)
+		std::rethrow_exception(reloadException);
+
+	modManager = std::move(reloadedManager);
 }
 
 const JsonNode & ModStateModel::getRepositoryData() const

--- a/lib/VCMIDirs.cpp
+++ b/lib/VCMIDirs.cpp
@@ -55,15 +55,30 @@ void IVCMIDirs::init()
 	bfs::create_directories(userSavePath());
 }
 
+boost::filesystem::path IVCMIDirs::userPath(EUserDirectory directory) const
+{
+	switch(directory)
+	{
+	case EUserDirectory::DATA:
+		return userDataPath();
+	case EUserDirectory::CACHE:
+		return userCachePath();
+	case EUserDirectory::CONFIG:
+		return userConfigPath();
+	case EUserDirectory::LOGS:
+		return userLogsPath();
+	case EUserDirectory::SAVES:
+		return userSavePath();
+	}
+	return {};
+}
+
+bool IVCMIDirs::setUserPath(EUserDirectory, const bfs::path &)
+{
+	return false;
+}
+
 #ifdef VCMI_WINDOWS
-
-#ifdef __MINGW32__
-	#define _WIN32_IE 0x0500
-
-	#ifndef CSIDL_MYDOCUMENTS
-	#define CSIDL_MYDOCUMENTS CSIDL_PERSONAL
-	#endif
-#endif // __MINGW32__
 
 #include <windows.h>
 #include <shlobj.h>
@@ -85,11 +100,14 @@ class VCMIDirsWIN32 final : public IVCMIDirs
 		bfs::path serverPath() const override;
 
 		bfs::path binaryPath() const override;
+		bool setUserPath(EUserDirectory directory, const bfs::path & path) override;
 
 	protected:
 		std::unique_ptr<JsonNode> dirsConfig;
+		bfs::path dirsConfigPath;
 
 		bfs::path getPathFromConfigOrDefault(const std::string& key, const std::function<bfs::path()>& fallbackFunc) const;
+		bool setPathInConfig(const std::string & key, const bfs::path & path);
 		bfs::path getDefaultUserDataPath() const;
 
 		std::wstring utf8ToWstring(const std::string& str) const;
@@ -101,17 +119,73 @@ VCMIDirsWIN32::VCMIDirsWIN32()
 {
 	wchar_t currentPath[MAX_PATH];
 	GetModuleFileNameW(nullptr, currentPath, MAX_PATH);
-	auto configPath = bfs::path(currentPath).parent_path() / "config" / "dirs.json";
+	dirsConfigPath = bfs::path(currentPath).parent_path() / "config" / "dirs.json";
 
-	if (!bfs::exists(configPath))
+	if (!bfs::exists(dirsConfigPath))
 		return;
 
-	std::ifstream in(configPath.wstring(), std::ios::binary);
+	std::ifstream in(dirsConfigPath.wstring(), std::ios::binary);
 	if (!in)
 		return;
 
 	std::string buffer((std::istreambuf_iterator<char>(in)), {});
-	dirsConfig = std::make_unique<JsonNode>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size(), pathToUtf8(configPath));
+	dirsConfig = std::make_unique<JsonNode>(reinterpret_cast<const std::byte*>(buffer.data()), buffer.size(), pathToUtf8(dirsConfigPath));
+}
+
+bool VCMIDirsWIN32::setPathInConfig(const std::string & key, const bfs::path & path)
+{
+	try
+	{
+		JsonNode updatedConfig = dirsConfig ? *dirsConfig : JsonNode(JsonMap{});
+		bfs::path preferredPath = path;
+		preferredPath.make_preferred();
+		updatedConfig[key].String() = pathToUtf8(preferredPath);
+		bfs::create_directories(dirsConfigPath.parent_path());
+
+		bfs::path temporaryPath = dirsConfigPath;
+		temporaryPath += ".tmp";
+		std::ofstream out(temporaryPath.wstring(), std::ios::binary | std::ios::trunc);
+		if(!out)
+			return false;
+		out << updatedConfig.toString() << '\n';
+		out.close();
+		if(!out)
+		{
+			bfs::remove(temporaryPath);
+			return false;
+		}
+		if(!MoveFileExW(temporaryPath.c_str(), dirsConfigPath.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+		{
+			bfs::remove(temporaryPath);
+			return false;
+		}
+
+		dirsConfig = std::make_unique<JsonNode>(std::move(updatedConfig));
+		IVCMIDirs::init();
+		return true;
+	}
+	catch(const std::exception &)
+	{
+		return false;
+	}
+}
+
+bool VCMIDirsWIN32::setUserPath(EUserDirectory directory, const bfs::path & path)
+{
+	switch(directory)
+	{
+	case EUserDirectory::DATA:
+		return setPathInConfig("userDataPath", path);
+	case EUserDirectory::CACHE:
+		return setPathInConfig("userCachePath", path);
+	case EUserDirectory::CONFIG:
+		return setPathInConfig("userConfigPath", path);
+	case EUserDirectory::LOGS:
+		return setPathInConfig("userLogsPath", path);
+	case EUserDirectory::SAVES:
+		return setPathInConfig("userSavePath", path);
+	}
+	return false;
 }
 
 std::string VCMIDirsWIN32::pathToUtf8(const bfs::path& path) const
@@ -135,7 +209,8 @@ std::wstring VCMIDirsWIN32::utf8ToWstring(const std::string& str) const
 	return result;
 }
 
-bfs::path VCMIDirsWIN32::getPathFromConfigOrDefault(const std::string& key, const std::function<bfs::path()>& fallbackFunc) const
+bfs::path VCMIDirsWIN32::getPathFromConfigOrDefault(
+	const std::string& key, const std::function<bfs::path()>& fallbackFunc) const
 {
 	if (!dirsConfig || !dirsConfig->isStruct())
 		return fallbackFunc();
@@ -569,7 +644,7 @@ bfs::path VCMIDirsXDG::binaryPath() const
 // Getters for interfaces are separated for clarity.
 namespace VCMIDirs
 {
-	const IVCMIDirs& get()
+	IVCMIDirs & get()
 	{
 		#ifdef VCMI_WINDOWS
 			static VCMIDirsWIN32 singleton;

--- a/lib/VCMIDirs.h
+++ b/lib/VCMIDirs.h
@@ -9,6 +9,15 @@
  */
 #pragma once
 
+enum class EUserDirectory
+{
+	DATA,
+	CACHE,
+	CONFIG,
+	LOGS,
+	SAVES
+};
+
 class DLL_LINKAGE IVCMIDirs
 {
 public:
@@ -26,6 +35,7 @@ public:
 
 	// Path to saved games
 	virtual boost::filesystem::path userSavePath() const;
+	boost::filesystem::path userPath(EUserDirectory directory) const;
 
 	// Path to "extracted" directory, used to temporarily hold extracted Original H3 files
 	virtual boost::filesystem::path userExtractedPath() const;
@@ -51,9 +61,12 @@ public:
 	// Updates directories what change name/path between versions.
 	// Function called automatically.
 	virtual void init();
+
+	/// Changes a user directory and persists it if supported by the platform.
+	virtual bool setUserPath(EUserDirectory directory, const boost::filesystem::path & path);
 };
 
 namespace VCMIDirs
 {
-	extern DLL_LINKAGE const IVCMIDirs & get();
+	extern DLL_LINKAGE IVCMIDirs & get();
 }

--- a/lib/logging/CBasicLogConfigurator.cpp
+++ b/lib/logging/CBasicLogConfigurator.cpp
@@ -14,8 +14,8 @@
 #include "../CConfigHandler.h"
 #include "../CConsoleHandler.h"
 
-CBasicLogConfigurator::CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console) :
-	filePath(std::move(filePath)), console(console), appendToLogFile(false) {}
+CBasicLogConfigurator::CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console, bool appendToLogFile) :
+	filePath(std::move(filePath)), console(console), appendToLogFile(appendToLogFile) {}
 
 void CBasicLogConfigurator::configureDefault()
 {

--- a/lib/logging/CBasicLogConfigurator.h
+++ b/lib/logging/CBasicLogConfigurator.h
@@ -20,7 +20,7 @@ enum class EConsoleTextColor : int8_t;
 class DLL_LINKAGE CBasicLogConfigurator
 {
 public:
-	CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console);
+	CBasicLogConfigurator(boost::filesystem::path filePath, CConsoleHandler * const console, bool appendToLogFile = false);
 
 	/// Configures the logging system by parsing the logging settings. It adds the console target and the file target to the global logger.
 	/// Doesn't throw, but logs on success or fault.


### PR DESCRIPTION
This PR finally adds option to change VCMI user directories directly from Launcher on Windows.

1) Logging is reconfigured at runtime, so changing the log directory does not require a restart or overwrite the existing log
2) Active downloads are paused before switching directories, because their files may be located in a directory that is being moved or replaced. They are resumed after the new filesystem is ready.
3) Mods data are loaded outside the GUI thread, because rebuilding the mod state during the filesystem reload can take some time and would otherwise freeze the launcher.
4) Existing directory content can be merged, backed up, or replaced during migration


<img width="1370" height="802" alt="image" src="https://github.com/user-attachments/assets/aa7e4eaf-21ec-4d13-9a68-77bf03a4dcc7" />

<img width="1367" height="800" alt="image" src="https://github.com/user-attachments/assets/f57c14b9-76b6-4ede-be8f-63140ccd8832" />

<img width="1371" height="802" alt="image" src="https://github.com/user-attachments/assets/e5b2a97c-9369-4d13-b604-695f924b2d2c" />

<img width="1369" height="798" alt="image" src="https://github.com/user-attachments/assets/d893b5b7-0857-4c79-b698-91a2e349eaaf" />


TODO:
- [x] Add required space handling for target location
- [ ] ?